### PR TITLE
Support closing two template argument lists with ">>" rather than "> >".

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -194,6 +194,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   restrictQualifier,
   declaratorId,
   typeId,
+  typeIdEnclosed,
   abstractDeclarator,
   ptrAbstractDeclarator,
   noptrAbstractDeclarator,
@@ -250,13 +251,16 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   // Templates
   templateDeclaration,
   templateParameterList,
+  templateParameterListEnclosed,
   templateParameter,
   typeParameter,
+  innerTypeParameter,
   simpleTemplateId,
   templateId,
   templateName,
   templateArgumentList,
   templateArgument,
+  innerTypeId,
   innerTemplateId,
   innerTemplateArgumentList,
   innerTemplateArgument,
@@ -420,10 +424,10 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
             primaryExpression,
 
-            b.sequence(CxxKeyword.DYNAMIC_CAST, "<", typeId, ">", "(", expression, ")"),
-            b.sequence(CxxKeyword.STATIC_CAST, "<", typeId, ">", "(", expression, ")"),
-            b.sequence(CxxKeyword.REINTERPRET_CAST, "<", typeId, ">", "(", expression, ")"),
-            b.sequence(CxxKeyword.CONST_CAST, "<", typeId, ">", "(", expression, ")"),
+            b.sequence(CxxKeyword.DYNAMIC_CAST, typeIdEnclosed, "(", expression, ")"),
+            b.sequence(CxxKeyword.STATIC_CAST, typeIdEnclosed, "(", expression, ")"),
+            b.sequence(CxxKeyword.REINTERPRET_CAST, typeIdEnclosed, "(", expression, ")"),
+            b.sequence(CxxKeyword.CONST_CAST, typeIdEnclosed, "(", expression, ")"),
             b.sequence(CxxKeyword.TYPEID, "(", expression, ")"),
             b.sequence(CxxKeyword.TYPEID, "(", typeId, ")")
         ),
@@ -452,6 +456,10 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         )
         )
         ).skipIfOneChild();
+
+        b.rule(typeIdEnclosed).is(b.firstOf(
+          b.sequence("<", typeId, ">"),
+          b.sequence("<", innerTypeId, ">>")));
 
     b.rule(expressionList).is(initializerList);
 
@@ -1253,7 +1261,11 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   }
 
   private static void templates(LexerfulGrammarBuilder b) {
-    b.rule(templateDeclaration).is(CxxKeyword.TEMPLATE, "<", templateParameterList, ">", declaration);
+    b.rule(templateDeclaration).is(CxxKeyword.TEMPLATE, templateParameterListEnclosed, declaration);
+
+    b.rule(templateParameterListEnclosed).is(b.firstOf(
+      b.sequence("<", templateParameterList, ">"),
+      b.sequence("<", b.zeroOrMore(templateParameter, ","), innerTypeParameter, ">>")));
 
     b.rule(templateParameterList).is(templateParameter, b.zeroOrMore(",", templateParameter));
 
@@ -1270,17 +1282,20 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
             b.sequence(CxxKeyword.CLASS, b.optional("..."), b.optional(IDENTIFIER)),
             b.sequence(CxxKeyword.TYPENAME, b.optional(IDENTIFIER), "=", typeId),
             b.sequence(CxxKeyword.TYPENAME, b.optional("..."), b.optional(IDENTIFIER)),
-            b.sequence(CxxKeyword.TEMPLATE, "<", templateParameterList, ">", CxxKeyword.CLASS, b.optional(IDENTIFIER), "=", idExpression),
-            b.sequence(CxxKeyword.TEMPLATE, "<", templateParameterList, ">", CxxKeyword.CLASS, b.optional("..."), b.optional(IDENTIFIER))
+            b.sequence(CxxKeyword.TEMPLATE, templateParameterListEnclosed, CxxKeyword.CLASS, b.optional(IDENTIFIER), "=", idExpression),
+            b.sequence(CxxKeyword.TEMPLATE, templateParameterListEnclosed, CxxKeyword.CLASS, b.optional("..."), b.optional(IDENTIFIER))
         )
         );
 
-    b.rule(simpleTemplateId).is(b.firstOf(
-        b.sequence(templateName, "<", b.optional(templateArgumentList), ">"),
-        b.sequence(templateName, "<", innerTemplateId, ">>")));
+    b.rule(innerTypeParameter).is(
+      b.firstOf(
+          b.sequence(CxxKeyword.CLASS, b.optional(IDENTIFIER), "=", innerTypeId),
+          b.sequence(CxxKeyword.TYPENAME, b.optional(IDENTIFIER), "=", innerTypeId),
+          b.sequence(CxxKeyword.TEMPLATE, templateParameterListEnclosed, CxxKeyword.CLASS, b.optional(IDENTIFIER), "=", innerTypeId)
+      )
+      );
 
-    b.rule(innerTemplateId).is(
-        b.zeroOrMore(templateArgument, b.optional("..."), ","),
+    b.rule(innerTypeId).is(
         b.optional(b.firstOf(
             // typeSpecifierSeq ~> [...] simpleTypeSpecifier
             b.sequence(nestedNameSpecifier, CxxKeyword.TEMPLATE),
@@ -1294,13 +1309,22 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
             )),
             templateName, "<", b.optional(innerTemplateArgumentList));
 
+    b.rule(simpleTemplateId).is(b.firstOf(
+        b.sequence(templateName, "<", b.optional(templateArgumentList), ">"),
+        b.sequence(templateName, "<", innerTemplateId, ">>")));
+
+    b.rule(innerTemplateId).is(
+        b.zeroOrMore(templateArgument, b.optional("..."), ","),
+        innerTypeId
+      );
+
     b.rule(templateId).is(
         b.firstOf(
             simpleTemplateId,
             b.sequence(operatorFunctionId, "<", b.optional(templateArgumentList), ">"),
             b.sequence(literalOperatorId, "<", b.optional(templateArgumentList), ">"),
-            b.sequence(operatorFunctionId, "<", b.optional(templateArgumentList, ","), innerTemplateId, ">>"),
-            b.sequence(literalOperatorId, "<", b.optional(templateArgumentList, ","), innerTemplateId, ">>")
+            b.sequence(operatorFunctionId, "<", innerTemplateId, ">>"),
+            b.sequence(literalOperatorId, "<", innerTemplateId, ">>")
         )
         );
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -191,6 +191,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   cvQualifierSeq,
   cvQualifier,
   refQualifier,
+  restrictQualifier,
   declaratorId,
   typeId,
   abstractDeclarator,
@@ -988,6 +989,10 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         b.firstOf("&", "&&")
         );
 
+    b.rule(restrictQualifier).is(
+        b.firstOf("restrict", "__restrict__", "__restrict")
+        );
+    
     b.rule(declaratorId).is(
         b.firstOf(
             b.sequence(b.optional(nestedNameSpecifier), className),

--- a/cxx-squid/src/test/resources/parser/own/declarations.cc
+++ b/cxx-squid/src/test/resources/parser/own/declarations.cc
@@ -23,3 +23,37 @@ std::vector<std::vector<int> > oldStyle;
 vector<vector<int>> newStyle;
 std::pair<const char*, std::vector<long int>> longNewStyle;
 
+template<class T, class Compare = std::less<T>>
+class list
+{
+};
+
+template <class T>
+struct List
+{
+    List<T>(){}
+    template <class U>
+    List<T>(List<U> & rhs) {}
+};
+
+template <int i>
+class X
+{
+} ;
+
+template <class T>
+class Y
+{
+    T data;
+} ;
+
+typedef unsigned int* B;
+
+void issue_49 ()
+{
+  X<(1>2)> x2;
+  Y<X<1>> x3;
+  vector<pair<int,int>> s;
+  List<unsigned*> ld;
+  static_cast<List<B>>(ld);
+}

--- a/cxx-squid/src/test/resources/parser/own/declarations.cc
+++ b/cxx-squid/src/test/resources/parser/own/declarations.cc
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <memory>
+#include <vector>
+#include <utility>
 using namespace std;
 
 
@@ -17,3 +19,7 @@ int var2;
 long var3;
 long long var4;
 unsigned long var5;
+std::vector<std::vector<int> > oldStyle;
+vector<vector<int>> newStyle;
+std::pair<const char*, std::vector<long int>> longNewStyle;
+


### PR DESCRIPTION
CxxGrammarImpl.java(templates): Introduce new language elements
    innerTemplateId, innerTemplateArgumentList, innerTemplateArgument
    to enable parsing of new nested template syntax.
CxxGrammarImpl.java(declarations): Relax rules for gnu style attribute syntax.
CxxGrammarImpl.java(declarations): Allow restrict als trailing type specifier.
.../own/declarations.cc: Add nested declarations for testing.

(cherry picked from commit 48f9750d64c748ecec1725eb7239bea3cb666344)

Conflicts:
	cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java