### PR TITLE
Set the correct parameter type for FileHeaderCheck

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/FileHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/FileHeaderCheck.java
@@ -47,9 +47,8 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
 
   @RuleProperty(
     key = "headerFormat",
-    description = "TEXT",
+    type = "TEXT",
     defaultValue = DEFAULT_HEADER_FORMAT)
-
   public String headerFormat = DEFAULT_HEADER_FORMAT;
 
   private Charset charset;


### PR DESCRIPTION
As mentioned in the commit message, the FileHeaderCheck rule is ending up with a 'STRING' parameter when it should be 'TEXT'. This is presumably a typo: 'description = ' rather than 'type = '. The parameter description is still set through the properties file.