### PR TITLE
remove deprecated metric COMMENT_BLANK_LINES

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
@@ -31,7 +31,6 @@ public enum CxxMetric implements MetricDef {
   CLASSES,
   COMPLEXITY,
   COMMENT_LINES,
-  COMMENT_BLANK_LINES,
   PUBLIC_API,
   PUBLIC_UNDOCUMENTED_API;
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
@@ -27,7 +27,7 @@ public class CxxMetricTest {
 
   @Test
   public void test() {
-    assertThat(CxxMetric.values()).hasSize(11);
+    assertThat(CxxMetric.values()).hasSize(10);
 
     for (CxxMetric metric : CxxMetric.values()) {
       assertThat(metric.getName()).isEqualTo(metric.name());

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -163,7 +163,6 @@ public final class CxxSquidSensor implements Sensor {
     context.saveMeasure(sonarFile, CoreMetrics.FUNCTIONS, squidFile.getDouble(CxxMetric.FUNCTIONS));
     context.saveMeasure(sonarFile, CoreMetrics.CLASSES, squidFile.getDouble(CxxMetric.CLASSES));
     context.saveMeasure(sonarFile, CoreMetrics.COMPLEXITY, squidFile.getDouble(CxxMetric.COMPLEXITY));
-    context.saveMeasure(sonarFile, CoreMetrics.COMMENT_BLANK_LINES, squidFile.getDouble(CxxMetric.COMMENT_BLANK_LINES));
     context.saveMeasure(sonarFile, CoreMetrics.COMMENT_LINES, squidFile.getDouble(CxxMetric.COMMENT_LINES));
     context.saveMeasure(sonarFile, CoreMetrics.PUBLIC_API, squidFile.getDouble(CxxMetric.PUBLIC_API));
     context.saveMeasure(sonarFile, CoreMetrics.PUBLIC_UNDOCUMENTED_API, squidFile.getDouble(CxxMetric.PUBLIC_UNDOCUMENTED_API));


### PR DESCRIPTION
The deprecated metric COMMENT_BLANK_LINES stops code analysis with SonarQube V5.0