### PR TITLE
simulate virtual files for xunit/provideDetails

### DIFF
--- a/integration-tests/features/test_execution_statistics.feature
+++ b/integration-tests/features/test_execution_statistics.feature
@@ -258,7 +258,30 @@ Feature: Providing test execution numbers
               | test_success_density | 0     |
               | test_execution_time  | 3     |
 
- 
+              
+ Scenario: Simulate virtual unit test file (provideDetails, filename tag)
+
+      Starting with SQ 4.2 virtual files are no more supported.
+      With 'boosttest-1.x-to-junit-1.0-dummy.xsl' it is possible to simulate this feature again.
+      The stylesheet set the filename tag to './cxx-xunit/dummy.cpp' additional the dummy
+      cpp unittest file in the test folder is needed.
+
+      GIVEN the project "boosttest_project"
+
+      WHEN I run "sonar-runner -X -Dsonar.cxx.xunit.xsltURL=boosttest-1.x-to-junit-dummy-1.0.xsl -Dsonar.tests=cxx-xunit -Dsonar.cxx.xunit.provideDetails=true -Dsonar.cxx.xunit.reportPath=btest_test_nested-test_suite.xml"
+
+      THEN the analysis finishes successfully
+          AND the analysis log contains no error/warning messages
+          AND the following metrics have following values:
+              | metric               | value |
+              | tests                | 4     |
+              | test_failures        | 0     |
+              | test_errors          | 4     |
+              | skipped_tests        | 0     |
+              | test_success_density | 0     |
+              | test_execution_time  | 3     |
+              
+              
   Scenario Outline: Importing unchanged boosttest reports in detailed mode (filename tag)
 
       Testcases in boosttest reports with setting 'log_level=all' also

--- a/integration-tests/testdata/boosttest_project/cxx-xunit/dummy.cpp
+++ b/integration-tests/testdata/boosttest_project/cxx-xunit/dummy.cpp
@@ -1,0 +1,1 @@
+// dummy unit test file

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/xunit/DefaultResourceFinder.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/xunit/DefaultResourceFinder.java
@@ -20,18 +20,15 @@
 package org.sonar.plugins.cxx.xunit;
 
 import java.io.File;
-
 import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.resources.Project;
 import org.sonar.api.batch.fs.FileSystem;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.plugins.cxx.CxxLanguage;
 
 public class DefaultResourceFinder implements ResourceFinder {
+
   public org.sonar.api.resources.File findInSonar(File file, SensorContext context, FileSystem fs, Project project) {
     List<File> files = Lists.newArrayList(fs.files(fs.predicates().is(file)));
     assert (files.size() <= 1);

--- a/sonar-cxx-plugin/src/main/resources/xsl/boosttest-1.x-to-junit-dummy-1.0.xsl
+++ b/sonar-cxx-plugin/src/main/resources/xsl/boosttest-1.x-to-junit-dummy-1.0.xsl
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:template match="/TestLog">
+    <xsl:element name="testsuite">
+
+      <xsl:choose>
+
+        <xsl:when test="boolean(//TestCase)">
+          <xsl:attribute name="tests">
+            <xsl:value-of select="count(//TestCase)"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="errors">
+            <xsl:value-of select="count(//TestCase/FatalError)+count(//TestCase/Exception)"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="failures">
+            <xsl:value-of select="count(//TestCase/Error)"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="skipped">0</xsl:attribute>
+
+          <xsl:attribute name="name">
+            <xsl:value-of select="//TestSuite/@name"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="filename"><![CDATA[./cxx-xunit/dummy.cpp]]></xsl:attribute>
+
+          <xsl:for-each select="//TestCase">
+            <xsl:call-template name="testCase"/>
+          </xsl:for-each>
+        </xsl:when>
+
+        <xsl:otherwise>
+          <xsl:variable name="countErrors" select="count(//FatalError)+count(//Exception)"/>
+          <xsl:variable name="countFailures" select="count(//Error)"/>
+
+          <xsl:attribute name="tests">
+            <xsl:value-of select="$countErrors+$countFailures"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="errors">
+            <xsl:value-of select="$countErrors"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="failures">
+            <xsl:value-of select="$countFailures"/>
+          </xsl:attribute>
+
+          <xsl:attribute name="skipped">0</xsl:attribute>
+
+          <xsl:attribute name="name">Master Test Suite</xsl:attribute>
+          <xsl:attribute name="filename"><![CDATA[./cxx-xunit/dummy.cpp]]></xsl:attribute>
+
+          <xsl:for-each select="./*">
+            <xsl:call-template name="testCase"/>
+          </xsl:for-each>
+        </xsl:otherwise>
+
+      </xsl:choose>
+
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="testCaseContent">
+
+    <xsl:variable name="currElt" select="."/>
+    <xsl:variable name="currEltName" select="name(.)"/>
+
+    <xsl:choose>
+
+      <xsl:when test="$currEltName='Error'">
+        <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
+        <xsl:value-of select="($currElt)/@file"/>
+        <xsl:text>(</xsl:text>
+        <xsl:value-of select="($currElt)/@line"/>
+        <xsl:text>) Error: </xsl:text>
+        <xsl:value-of select="($currElt)"/>
+        <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
+      </xsl:when>
+
+      <xsl:when test="$currEltName='FatalError'">
+        <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
+        <xsl:value-of select="($currElt)/@file"/>
+        <xsl:text>(</xsl:text>
+        <xsl:value-of select="($currElt)/@line"/>
+        <xsl:text>) FatalError: </xsl:text>
+        <xsl:value-of select="($currElt)"/>
+        <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
+      </xsl:when>
+
+      <xsl:when test="$currEltName='Exception'">
+        <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
+        <xsl:value-of select="($currElt)/@file"/>
+        <xsl:text>(</xsl:text>
+        <xsl:value-of select="($currElt)/@line"/>
+        <xsl:text>) Exception: </xsl:text>
+        <xsl:value-of select="($currElt)"/>
+        <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
+      </xsl:when>
+
+    </xsl:choose>
+
+  </xsl:template>
+
+  <xsl:template name="testCase">
+
+    <xsl:variable name="curElt" select="."/>
+    <xsl:variable name="suiteName">
+      <xsl:for-each select="($curElt/ancestor::TestSuite/TestSuite)">
+        <xsl:text>::</xsl:text>
+        <xsl:value-of select="./@name"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:variable name="namespace" select="substring($suiteName,3)"/>
+
+    <xsl:element name="testcase">
+      <xsl:variable name="elt" select="(child::*[position()=1])"/>
+      <xsl:variable name="time" select="TestingTime"/>
+
+      <xsl:variable name="name">
+        <xsl:choose>
+          <xsl:when test="string-length(@name)">
+            <xsl:value-of select="@name"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(name(.),string(position()))"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:attribute name="classname">
+        <xsl:choose>
+          <xsl:when test="string-length($namespace)">
+            <xsl:value-of select="concat($namespace,'::',$name)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$name"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+
+      <xsl:attribute name="name">
+        <xsl:value-of select="$name"/>
+      </xsl:attribute>
+
+      <xsl:if test="$time&gt;0">
+        <xsl:attribute name="time">
+          <xsl:value-of select="$time div 1000000"/>
+        </xsl:attribute>
+      </xsl:if>
+
+      <xsl:variable name="countErrors" select="count(Error)"/>
+      <xsl:variable name="countFailures" select="count(FatalError)+count(Exception)"/>
+
+      <xsl:choose>
+        <xsl:when test="$countFailures&gt;0">
+          <xsl:for-each select="./FatalError | ./Exception">
+            <xsl:element name="error">
+              <xsl:call-template name="testCaseContent"/>
+            </xsl:element>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:when test="$countErrors&gt;0">
+          <xsl:for-each select="./Error">
+            <xsl:element name="failure">
+              <xsl:call-template name="testCaseContent"/>
+            </xsl:element>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:when test="name()='Error'">
+          <xsl:element name="failure">
+            <xsl:call-template name="testCaseContent"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:when test="name()='FatalError' or name()='Exception'">
+          <xsl:element name="error">
+            <xsl:call-template name="testCaseContent"/>
+          </xsl:element>
+        </xsl:when>
+      </xsl:choose>
+
+    </xsl:element>
+
+  </xsl:template>
+
+  <xsl:template match="text()|@*"/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- support relative path for filename tags
- add new boosttest-1.x-to-junit-dummy-1.0.xsl which set filename always to '.\cxx_xunit_dummy.cpp'
- add new integration test