### PR TITLE
Fix slow token rescanning during preprocessing.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -543,7 +543,7 @@ public class CxxPreprocessor extends Preprocessor {
 
       if (macro.params == null) {
         tokensConsumed = 1;
-        replTokens = expandMacro(macro.name, serialize(evaluateHashhashOperators(macro.body)));
+        replTokens = new LinkedList<Token>(expandMacro(macro.name, serialize(evaluateHashhashOperators(macro.body))));
       }
       else {
         int tokensConsumedMatchingArgs = expandFunctionLikeMacro(macro.name,
@@ -568,7 +568,7 @@ public class CxxPreprocessor extends Preprocessor {
             action = handleIdentifiersAndKeywords(rest, c, filename);
           }
           if (action == PreprocessorAction.NO_OPERATION) {
-            replTokens = replTokens.subList(1, replTokens.size());
+            replTokens.remove(0);
             outTokens.add(c);
           }
           else {
@@ -576,10 +576,10 @@ public class CxxPreprocessor extends Preprocessor {
             int tokensConsumedRescanning = action.getNumberOfConsumedTokens();
             if (tokensConsumedRescanning >= replTokens.size()) {
               tokensConsumed += tokensConsumedRescanning - replTokens.size();
-              replTokens = replTokens.subList(replTokens.size(), replTokens.size());
+              replTokens.subList(0, replTokens.size()).clear();
             }
             else {
-              replTokens = replTokens.subList(tokensConsumedRescanning, replTokens.size());
+              replTokens.subList(0, tokensConsumedRescanning).clear();
             }
           }
         }

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -576,7 +576,7 @@ public class CxxPreprocessor extends Preprocessor {
             int tokensConsumedRescanning = action.getNumberOfConsumedTokens();
             if (tokensConsumedRescanning >= replTokens.size()) {
               tokensConsumed += tokensConsumedRescanning - replTokens.size();
-              replTokens.subList(0, replTokens.size()).clear();
+              replTokens.clear();
             }
             else {
               replTokens.subList(0, tokensConsumedRescanning).clear();


### PR DESCRIPTION
The loop to rescan tokens during preprocessing can become very slow when expanding a macro that consists of many tokens.  For instance, preprocessing the following can take several **minutes**:

```C++
void foo() {}

#define A foo();
#define FOO() \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A \
    A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A

int main()
{
    FOO()
    return 0;
}
```

You can add more lines of As to make it take an arbitrarily long amount of time.

The problem is the calls like `replTokens = replTokens.subList(...)` on each iteration of the loop.  `subList` doesn't return a new list but a `SubList` that's a "view" of the existing list.  And calling `subList` on a `SubList` doesn't create a view of the underlying list but instead creates a view of the `SubList` or a 'view of a view".  After running through the loop a few times you now have a "view of a view of a view of a view of ..." which gets very slow.

Modifying the existing list in-place solves this problem.

I'd like to have a test for this but I'm not sure how to write one when the only observable difference in behavior is how long it takes to run.
