### PR TITLE
An argument called "final" generates a parsing error #410

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/StandardDefinitions.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/StandardDefinitions.java
@@ -55,6 +55,7 @@ public final class StandardDefinitions {
       .put("dynamic_cast", "__dynamic_cast")
       .put("explicit", "__explicit")
       .put("export", "__export")
+      .put("final", "__final")
       .put("friend", "__friend")
       .put("mutable", "__mutable")
       .put("namespace", "__namespace")


### PR DESCRIPTION
- add final macro to let C code be parsed by C++ parser
- close #410