### PR TITLE
improve checks with "using" keyword

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
@@ -52,7 +52,8 @@ public class UsingNamespaceInHeaderCheck extends SquidCheck<Grammar> {
 
   @Override
   public void visitNode(AstNode node) {
-    if ((node.getTokenValue().equals("using")) && (isHeader(getContext().getFile().getName()))) {
+    if (isHeader(getContext().getFile().getName()) &&
+        node.getTokenValue().equals("using") && node.getFirstChild().getChildren().toString().contains("namespace")) {
       getContext().createLineViolation(this, "Using namespace are not allowed in header files.", node);
       }
     }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
@@ -36,12 +36,12 @@ public class TooManyStatementsPerLineCheckTest {
     check.excludeCaseBreak = false;
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/TooManyStatementsPerLine.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(10).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
-        .next().atLine(13)
-        .next().atLine(16)
+        .next().atLine(17).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
         .next().atLine(20)
-        .next().atLine(22)
-        .next().atLine(24)
+        .next().atLine(23)
+        .next().atLine(27)
+        .next().atLine(29)
+        .next().atLine(31)
         .noMore();
   }
 
@@ -57,11 +57,11 @@ public class TooManyStatementsPerLineCheckTest {
     check.excludeCaseBreak = true;
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/TooManyStatementsPerLine.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(10).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
-        .next().atLine(13)
-        .next().atLine(16)
+        .next().atLine(17).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
         .next().atLine(20)
-        .next().atLine(24)
+        .next().atLine(23)
+        .next().atLine(27)
+        .next().atLine(31)
         .noMore();
   }
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheckTest.java
@@ -34,6 +34,7 @@ public class UsingNamespaceInHeaderCheckTest {
 
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/UsingNamespaceInHeader.h"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(7).withMessage("Using namespace are not allowed in header files.");
+        .next().atLine(11).withMessage("Using namespace are not allowed in header files.")
+        .noMore();
   }
 }

--- a/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
+++ b/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
@@ -1,9 +1,16 @@
+#include <string>
+#include <ios>
+#include <type_traits>
+
 int doSomething();
 int doSomethingElse();
 bool condition = true;
 #define TEST(a,b) if (a) {    \
                   } if (b) {  \
                   }
+
+// without alias
+
 class TooManyStatementsPerLine {
     int a; int b; // OK - not a statement
     void myfunc() {
@@ -25,3 +32,62 @@ class TooManyStatementsPerLine {
         }
     }
 };
+
+// alias shall not be considered
+// http://en.cppreference.com/w/cpp/language/type_alias
+
+// type alias, identical to
+// typedef std::ios_base::fmtflags flags;
+using flags = typename std::ios_base::fmtflags;
+// the name 'flags' now denotes a type:
+flags fl = std::ios_base::dec;
+
+// type alias, identical to
+// typedef void (*func)(int, int);
+using func = void(*) (int, int);
+// the name 'func' now denotes a pointer to function:
+void example(int, int) {}
+func fn = example;
+
+// template type alias
+template<class T> using ptr = T*;
+// the name 'ptr<T>' is now an alias for pointer to T
+ptr<int> x;
+
+// type alias used to hide a template parameter 
+template <class CharT> using mystring =
+std::basic_string<CharT, std::char_traits<CharT>>;
+mystring<char> str;
+
+// type alias can introduce a member typedef name
+template<typename T>
+struct Container {
+	using value_type = T;
+};
+// which can be used in generic programming
+template<typename Container>
+void fn2(const Container& c)
+{
+	typename Container::value_type n;
+}
+
+// type alias used to simplify the syntax of std::enable_if
+template <typename T> using Invoke =
+typename T::type;
+template <typename Condition> using EnableIf =
+Invoke<std::enable_if<Condition::value>>;
+template <typename T, typename = EnableIf<std::is_polymorphic<T>>>
+int fpoly_only(T t) { return 1; }
+
+struct S { virtual ~S() {} };
+int main()
+{
+	Container<int> c;
+	fn2(c); // Container::value_type will be int in this function
+
+			//    fpoly_only(c); // error, enable_if prohibits this
+	S s;
+	fpoly_only(s); // okay, enable_if allows this
+}
+
+

--- a/cxx-checks/src/test/resources/checks/UsingNamespaceInHeader.h
+++ b/cxx-checks/src/test/resources/checks/UsingNamespaceInHeader.h
@@ -1,10 +1,18 @@
 // Foo.h
+#include <string>
+#include <ios>
+#include <type_traits>
+
 namespace Foo
 {
     void fooFunc( );
 }
 
 using namespace std;
+
+// alias for types or template shall not be detected
+// see more details http://en.cppreference.com/w/cpp/language/type_alias
+using flags = std::ios_base::fmtflags;
 
 // Foo1.cpp
 namespace Foo


### PR DESCRIPTION
Analysis for https://github.com/wenns/sonar-cxx/issues/445#issuecomment-91623590 showed a false-positive in *UsingNamespaceInHeaderCheck* but the problem in *TooManyStatementsPerLineCheck* is not reproducible.