### PR TITLE
fix-switch-statement

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -612,9 +612,11 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
       b.sequence(CxxKeyword.IF, "(", condition, ")", statement, b.optional(CxxKeyword.ELSE, statement))
       );
 
-    b.rule(switchStatement).is(CxxKeyword.SWITCH, "(", condition, ")", "{", switchBlockStatementGroups, "}");
+    b.rule(switchStatement).is(CxxKeyword.SWITCH, "(", condition, ")", 
+        b.firstOf(b.sequence("{", switchBlockStatementGroups, "}"), 
+                  switchBlockStatementGroups));
 
-    b.rule(switchBlockStatementGroups).is(b.zeroOrMore(switchBlockStatementGroup));
+    b.rule(switchBlockStatementGroups).is("{", b.zeroOrMore(switchBlockStatementGroup), "}");
 
     b.rule(switchBlockStatementGroup).is(switchLabelStatement, b.optional(emptyStatement), b.zeroOrMore(statement), b.optional(jumpStatement));
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -137,9 +137,7 @@ public class StatementTest extends ParserBaseTest {
     p.setRootRule(g.rule(CxxGrammarImpl.switchStatement));
 
     assertThat(p).matches("switch (0) { default : break; }");
-
-    //TODO: make this work.
-//    assertThat(p).matches("switch (0) { {default : break;} }");
+    assertThat(p).matches("switch (0) { {default : break;} }");
   }
 
 


### PR DESCRIPTION
The following statement was failing in unit test
switchStatement_reallife:
switch (0) { {default : break;} }

see #381