### PR TITLE
CppCheck sensor shall support project findings

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
@@ -47,8 +47,7 @@ public class CppcheckParserV1 implements CppcheckParser {
    * {@inheritDoc}
    */
   public void processReport(final Project project, final SensorContext context, File report)
-    throws javax.xml.stream.XMLStreamException
-  {
+    throws javax.xml.stream.XMLStreamException {
     CxxUtils.LOG.info("Parsing 'Cppckeck V1' format");
 
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
@@ -70,6 +69,11 @@ public class CppcheckParserV1 implements CppcheckParser {
             String line = errorCursor.getAttrValue("line");
             String id = errorCursor.getAttrValue("id");
             String msg = errorCursor.getAttrValue("msg");
+
+            if ("*".equals(file)) { // findings on project level
+              file = null;
+              line = null;
+            }
 
             if (isInputValid(file, line, id, msg)) {
               sensor.saveUniqueViolation(project, context, CxxCppCheckRuleRepository.KEY, file, line, id, msg);

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
@@ -83,6 +83,11 @@ public class CppcheckParserV2 implements CppcheckParser {
                 if (locationCursor.getNext() != null) {
                   file = locationCursor.getAttrValue("file");
                   line = locationCursor.getAttrValue("line");
+
+                  if ("*".equals(file)) { // findings on project level
+                    file = null;
+                    line = null;
+                  }
                 }
 
                 if (isInputValid(file, line, id, msg)) {
@@ -110,7 +115,7 @@ public class CppcheckParserV2 implements CppcheckParser {
         }
         return msg;
       }
-        
+
       private boolean isInputValid(String file, String line, String id, String msg) {
         return !StringUtils.isEmpty(id) && !StringUtils.isEmpty(msg);
       }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
@@ -19,16 +19,13 @@
  */
 package org.sonar.plugins.cxx.cppcheck;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
 import static org.mockito.Matchers.any;
+
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.component.ResourcePerspectives;
@@ -40,7 +37,9 @@ import org.sonar.api.resources.File;
 import org.sonar.api.resources.Project;
 import org.sonar.plugins.cxx.TestUtils;
 import org.sonar.api.batch.bootstrap.ProjectReactor;
-import org.sonar.plugins.cxx.CxxPlugin;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class CxxCppCheckSensorTest {
 
@@ -72,7 +71,7 @@ public class CxxCppCheckSensorTest {
   @Test
   public void shouldReportCorrectViolations() {
     sensor.analyse(project, context);
-    verify(issuable, times(7)).addIssue(any(Issue.class));
+    verify(issuable, times(9)).addIssue(any(Issue.class));
   }
 
   @Test
@@ -81,7 +80,7 @@ public class CxxCppCheckSensorTest {
       "cppcheck-reports/cppcheck-result-projectlevelviolation-V1.xml");
     sensor = new CxxCppCheckSensor(perspectives, settings, fs, profile, reactor);
     sensor.analyse(project, context);
-    verify(issuable, times(1)).addIssue(any(Issue.class));
+    verify(issuable, times(3)).addIssue(any(Issue.class));
   }
 
   @Test
@@ -90,7 +89,7 @@ public class CxxCppCheckSensorTest {
       "cppcheck-reports/cppcheck-result-projectlevelviolation-V2.xml");
     sensor = new CxxCppCheckSensor(perspectives, settings, fs, profile, reactor);
     sensor.analyse(project, context);
-    verify(issuable, times(1)).addIssue(any(Issue.class));
+    verify(issuable, times(3)).addIssue(any(Issue.class));
   }
 
   @Test
@@ -111,5 +110,5 @@ public class CxxCppCheckSensorTest {
     when(context.getResource((File) anyObject())).thenReturn(null);
     sensor.analyse(project, context);
     verify(issuable, times(0)).addIssue(any(Issue.class));
-  }   
+  }
 }

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-projectlevelviolation-V1.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-projectlevelviolation-V1.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
 <results>
-<error id="someid" severity="error" msg="somemessage"/>
+<error id="id1" severity="error" msg="somemessage"/>
+<error id="id2" file="*" severity="error" msg="somemessage"/>
+<error id="id3" file="*" line="0" severity="error" msg="somemessage"/>
 </results>

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-projectlevelviolation-V2.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-projectlevelviolation-V2.xml
@@ -2,6 +2,12 @@
 <results version="2">
   <cppcheck version="1.53"/>
   <errors>  
-    <error id="someid" severity="error" msg="somemessage"/>
+    <error id="id1" severity="error" msg="somemessage"/>
+    <error id="id2" severity="warning" msg="somemessage">
+      <location file="*"/>
+    </error>    
+    <error id="id3" severity="information" msg="somemessage" verbose="xyz">
+      <location file="*" line="0"/>
+    </error>
   </errors>
 </results>


### PR DESCRIPTION
add support for project findings with file="*"
close #491

Example:
```XML
<error id="unmatchedSuppression" severity="information" msg="Unmatched suppression: unusedFunction" verbose="Unmatched suppression: unusedFunction">
  <location file="*" line="0"/>
</error>
```