### PR TITLE
Add fallback for 'reactor' report search in CxxCoverageSensor

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -80,17 +80,25 @@ public class CxxCoverageSensor extends CxxReportSensor {
 
     CxxUtils.LOG.debug("Parsing coverage reports");
     List<File> reports = getReports(conf, reactor.getRoot().getBaseDir().getAbsolutePath(), REPORT_PATH_KEY, DEFAULT_REPORT_PATH);
-
+    if (reports.isEmpty()) {
+        reports = getReports(conf, fs.baseDir().getPath(), REPORT_PATH_KEY, DEFAULT_REPORT_PATH);
+    }
     Map<String, CoverageMeasuresBuilder> coverageMeasures = processReports(project, context, reports);
     saveMeasures(project, context, coverageMeasures, CoverageType.UT_COVERAGE);
 
     CxxUtils.LOG.debug("Parsing integration test coverage reports");
     List<File> itReports = getReports(conf, reactor.getRoot().getBaseDir().getAbsolutePath(), IT_REPORT_PATH_KEY, IT_DEFAULT_REPORT_PATH);
+    if (itReports.isEmpty()) {
+        itReports = getReports(conf, fs.baseDir().getPath(), IT_REPORT_PATH_KEY, IT_DEFAULT_REPORT_PATH);
+    }
     Map<String, CoverageMeasuresBuilder> itCoverageMeasures = processReports(project, context, itReports);
     saveMeasures(project, context, itCoverageMeasures, CoverageType.IT_COVERAGE);
 
     CxxUtils.LOG.debug("Parsing overall test coverage reports");
     List<File> overallReports = getReports(conf, reactor.getRoot().getBaseDir().getAbsolutePath(), OVERALL_REPORT_PATH_KEY, OVERALL_DEFAULT_REPORT_PATH);
+    if (overallReports.isEmpty()) {
+        overallReports = getReports(conf, fs.baseDir().getPath(), OVERALL_REPORT_PATH_KEY, OVERALL_DEFAULT_REPORT_PATH);
+    }
     Map<String, CoverageMeasuresBuilder> overallCoverageMeasures = processReports(project, context, overallReports);
     saveMeasures(project, context, overallCoverageMeasures, CoverageType.OVERALL_COVERAGE);
 


### PR DESCRIPTION
Our mixed Java/C++ project setup follows quite a traditional multi-module Maven project configuration, but the reactor changes introduced in e714d3e7ee14a51dbb4b5257d55f92cc989a0f46 break the CxxCoverageSensor for us.

It's no longer possible to use a relative report path for `sonar.cxx.coverage.reportPath` such as `target/gcovr/report.xml` in a multi-module project. This filter is used from the reactor root (`reactor.getRoot().getBaseDir().getAbsolutePath()`) and won't match the individual module reports.

All other Sensor classes inherit a [`reports.isEmpty()` check](https://github.com/wenns/sonar-cxx/blob/7c7bca55ca186b9a721014f7700250ff9bfb641f/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java#L106) from CxxReportSensor to revert from the reactor-based root directory to a local root directory when searching for reports, so other sensors are not affected by this.

This commit adds the same check to the three types of coverage reports.