### PR TITLE
SQALE characteristics for other rules

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -256,8 +256,18 @@ public final class CxxPlugin extends SonarPlugin {
       .multiValues(true)
       .subCategory(subcateg)
       .index(12)
+      .build(),
+    
+      PropertyDefinition.builder(CxxExternalRuleRepository.SQALES_KEY)
+      .name("External SQALE characteristics")
+      .description("SQALE characteristics for 'external' code analysers. Use one value per rule set."
+        + " See <a href='https://github.com/wenns/sonar-cxx/wiki/Extending-the-code-analysis'>this page</a> for details.")
+      .type(PropertyType.TEXT)
+      .multiValues(true)
+      .subCategory(subcateg)
+      .index(13)
       .build()
-      );
+    );
   }
 
   private static List<PropertyDefinition> compilerWarningsProperties() {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxSqaleXmlLoader.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxSqaleXmlLoader.java
@@ -1,0 +1,186 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.utils;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Maps;
+import com.google.common.io.Resources;
+import org.codehaus.staxmate.SMInputFactory;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+import org.codehaus.staxmate.in.SMInputCursor;
+import org.sonar.api.server.debt.DebtRemediationFunction;
+import org.sonar.api.server.rule.RulesDefinition.DebtRemediationFunctions;
+import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ *
+ * This is a copy of
+ * http://grepcode.com/file_/repo1.maven.org/maven2/org.codehaus.sonar.sslr-squid-bridge/sslr-squid-bridge/2.6/org/sonar/squidbridge/rules/SqaleXmlLoader.java/?v=source.
+ * Currently it is not possible to derive and extend from SqaleXmlLoader because
+ * most methods are private.
+ *
+ * @todo check in later version if direct usage of SqaleXmlLoader is possible.
+ */
+public class CxxSqaleXmlLoader {
+
+  private NewRepository repository;
+
+  public CxxSqaleXmlLoader(NewRepository repository) {
+    this.repository = repository;
+  }
+
+  public static void load(NewRepository repository, String xmlResourcePath) {
+    new CxxSqaleXmlLoader(repository).loadXmlResource(xmlResourcePath);
+  }
+
+  public static void load(NewRepository repository, Reader reader) {
+    new CxxSqaleXmlLoader(repository).loadXmlStream(reader);
+  }
+
+  public void loadXmlStream(Reader reader) {
+    XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+    xmlFactory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
+    xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.FALSE);
+    // just so it won't try to load DTD in if there's DOCTYPE
+    xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+    xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
+    SMInputFactory inputFactory = new SMInputFactory(xmlFactory);
+    try {
+      processRoot(reader, inputFactory);
+    } catch (XMLStreamException e) {
+      throw new IllegalStateException("SQALE XML is not valid: ", e);
+    }
+  }
+
+  public void loadXmlResource(String resourcePath) {
+    loadXmlStream(reader(resourcePath));
+  }
+
+  private void processRoot(Reader reader, SMInputFactory inputFactory) throws XMLStreamException {
+    SMHierarchicCursor rootCursor = inputFactory.rootElementCursor(reader);
+    rootCursor.advance();
+    SMInputCursor charCursor = rootCursor.childElementCursor("chc");
+    while (charCursor.getNext() != null) {
+      SMInputCursor subCharCursor = charCursor.childElementCursor("chc");
+      while (subCharCursor.getNext() != null) {
+        processSubChar(subCharCursor);
+      }
+    }
+  }
+
+  private void processSubChar(SMInputCursor subCharCursor) throws XMLStreamException {
+    String subCharName = null;
+    SMInputCursor subCharChildCursor = subCharCursor.childElementCursor();
+    while (subCharChildCursor.getNext() != null) {
+      String childName = subCharChildCursor.getLocalName();
+      if ("key".equals(childName)) {
+        subCharName = subCharChildCursor.getElemStringValue();
+      }
+      if ("chc".equals(childName)) {
+        processRule(subCharName, subCharChildCursor);
+      }
+    }
+  }
+
+  private void processRule(String subCharName, SMInputCursor ruleCursor) throws XMLStreamException {
+    SMInputCursor ruleChildCursor = ruleCursor.childElementCursor();
+    String ruleKey = null;
+    String remediationFunction = null;
+    String remediationFactor = null;
+    String offset = null;
+    while (ruleChildCursor.getNext() != null) {
+      String childName = ruleChildCursor.getLocalName();
+      if ("rule-key".equals(childName)) {
+        ruleKey = ruleChildCursor.getElemStringValue();
+      }
+      if ("prop".equals(childName)) {
+        Map<String, String> propMap = childrenMap(ruleChildCursor.childElementCursor());
+        String key = propMap.get("key");
+        if ("remediationFunction".equals(key)) {
+          remediationFunction = propMap.get("txt");
+        }
+        if ("offset".equals(key)) {
+          offset = timeValue(propMap);
+        }
+        if ("remediationFactor".equals(key)) {
+          remediationFactor = timeValue(propMap);
+        }
+      }
+    }
+    NewRule rule = repository.rule(ruleKey);
+    if (rule != null) {
+      rule.setDebtSubCharacteristic(subCharName);
+      rule.setDebtRemediationFunction(remediationFunction(
+        rule.debtRemediationFunctions(), remediationFunction, offset, remediationFactor));
+    }
+  }
+
+  private String timeValue(Map<String, String> propMap) {
+    String timeUnit = propMap.get("txt");
+    if ("mn".equals(timeUnit)) {
+      timeUnit = "min";
+    }
+    String value = propMap.get("val");
+    if (value.indexOf('.') > -1) {
+      value = value.substring(0, value.indexOf('.'));
+    }
+    return value + timeUnit;
+  }
+
+  private DebtRemediationFunction remediationFunction(DebtRemediationFunctions functions,
+    String remediationFunction, String offset, String remediationFactor) {
+    if ("CONSTANT_ISSUE".equalsIgnoreCase(remediationFunction)) {
+      return functions.constantPerIssue(offset);
+    } else if ("LINEAR".equalsIgnoreCase(remediationFunction)) {
+      return functions.linear(remediationFactor);
+    } else if ("LINEAR_OFFSET".equalsIgnoreCase(remediationFunction)) {
+      return functions.linearWithOffset(remediationFactor, offset);
+    }
+    return null;
+  }
+
+  private Map<String, String> childrenMap(SMInputCursor cursor) throws XMLStreamException {
+    Map<String, String> map = Maps.newHashMap();
+    while (cursor.getNext() != null) {
+      map.put(cursor.getLocalName(), cursor.getElemStringValue());
+    }
+    return map;
+  }
+
+  private Reader reader(String resourcePath) {
+    URL url = Resources.getResource(CxxSqaleXmlLoader.class, resourcePath);
+    try {
+      return Resources.newReaderSupplier(url, Charsets.UTF_8).getInput();
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not read " + resourcePath, e);
+    }
+  }
+
+}

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -27,6 +27,6 @@ public class CxxPluginTest {
   @Test
   public void testGetExtensions() throws Exception {
     CxxPlugin plugin = new CxxPlugin();
-    assertEquals(61, plugin.getExtensions().size());
+    assertEquals(62, plugin.getExtensions().size());
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxRuleRepositoryTest.java
@@ -22,17 +22,18 @@ package org.sonar.plugins.cxx;
 import static org.fest.assertions.Assertions.assertThat;
 import org.junit.Test;
 import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.cxx.checks.CheckList;
 
 public class CxxRuleRepositoryTest {
-  
+
   @Test
-  public void test() {
+  public void rulesTest() {
     RulesDefinition.Context context = new RulesDefinition.Context();
     assertThat(context.repositories()).isEmpty();
 
     new CxxRuleRepository().define(context);
 
     assertThat(context.repositories()).hasSize(1);
-    assertThat(context.repository("cxx").rules()).hasSize(41);
-  }  
+    assertThat(context.repository(CheckList.REPOSITORY_KEY).rules()).hasSize(41);
+  }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepositoryTest.java
@@ -23,12 +23,15 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import org.junit.Test;
 import org.sonar.api.config.Settings;
+import org.sonar.api.server.debt.DebtRemediationFunction;
+import org.sonar.api.server.debt.DebtRemediationFunction.Type;
 import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.Rule;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
 public class CxxExternalRuleRepositoryTest {
 
-  String profile = "<?xml version=\"1.0\" encoding=\"ASCII\"?>\n"
+  String profile1 = "<?xml version=\"1.0\" encoding=\"ASCII\"?>\n"
     + "<rules>\n"
     + "    <rule key=\"cpplint.readability/nolint-0\">\n"
     + "        <name><![CDATA[ Unknown NOLINT error category: %s  % category]]></name>\n"
@@ -42,7 +45,47 @@ public class CxxExternalRuleRepositoryTest {
     + "        <category name=\"readability\" />\n"
     + "        <description>descr</description>\n"
     + "    </rule></rules>";
-
+  
+  String profile2 = "<?xml version=\"1.0\" encoding=\"ASCII\"?>\n"
+    + "<rules>\n"
+    + "    <rule key=\"key\">\n"
+    + "        <name><![CDATA[name]]></name>\n"
+    + "        <configKey><![CDATA[configKey]]></configKey>\n"
+    + "        <category name=\"category\" />\n"
+    + "        <description><![CDATA[description]]></description>\n"
+    + "    </rule>\n"
+    + "</rules>";
+  
+  String sqale2 = "<?xml version=\"1.0\"?>\n"
+    + "<sqale>\n"
+    + "  <chc>\n"
+    + "    <key>PORTABILITY</key>\n"
+    + "    <name>Portability</name>\n"
+    + "    <chc>\n"
+    + "      <key>COMPILER_RELATED_PORTABILITY</key>\n"
+    + "      <name>Compiler related portability</name>\n"
+    + "      <chc>\n"
+    + "        <rule-repo>other</rule-repo>\n"
+    + "        <rule-key>key</rule-key>\n"
+    + "        <prop>\n"
+    + "          <key>remediationFunction</key>\n"
+    + "          <txt>linear_offset</txt>\n"
+    + "        </prop>\n"
+    + "        <prop>\n"
+    + "          <key>remediationFactor</key>\n"
+    + "          <val>5</val>\n"
+    + "          <txt>mn</txt>\n"
+    + "        </prop>\n"
+    + "        <prop>\n"
+    + "          <key>offset</key>\n"
+    + "          <val>10</val>\n"
+    + "          <txt>mn</txt>\n"
+    + "        </prop>\n"
+    + "      </chc>\n"
+    + "    </chc>\n"
+    + "  </chc>\n"
+    + "</sqale>";
+  
   @Test
   public void verifyTemplateRuleIsFound() {
     CxxExternalRuleRepository def = new CxxExternalRuleRepository(
@@ -58,7 +101,7 @@ public class CxxExternalRuleRepositoryTest {
   @Test
   public void createNonEmptyRulesTest() {
     Settings settings = new Settings();
-    settings.appendProperty(CxxExternalRuleRepository.RULES_KEY, profile);
+    settings.appendProperty(CxxExternalRuleRepository.RULES_KEY, profile1);
     CxxExternalRuleRepository def = new CxxExternalRuleRepository(
       new RulesDefinitionXmlLoader(), settings);
 
@@ -81,5 +124,35 @@ public class CxxExternalRuleRepositoryTest {
 
     RulesDefinition.Repository repo = context.repository(CxxExternalRuleRepository.KEY);
     assertThat(repo.rules()).hasSize(1);
+  }
+  
+  @Test
+  public void verifyRuleValuesTest() {
+    Settings settings = new Settings();
+    settings.appendProperty(CxxExternalRuleRepository.RULES_KEY, profile2);
+    settings.appendProperty(CxxExternalRuleRepository.SQALES_KEY, sqale2);
+    CxxExternalRuleRepository def = new CxxExternalRuleRepository(
+      new RulesDefinitionXmlLoader(), settings);
+
+    RulesDefinition.Context context = new RulesDefinition.Context();
+    def.define(context);
+
+    RulesDefinition.Repository repo = context.repository(CxxExternalRuleRepository.KEY);   
+    Rule rule = repo.rule("key");
+    assertThat(rule).isNotNull();
+    
+    // from rule.xml
+    assertThat(rule.key()).isEqualTo("key");
+    assertThat(rule.name()).isEqualTo("name");
+    assertThat(rule.internalKey()).isEqualTo("configKey");
+    assertThat(rule.htmlDescription()).isEqualTo("description");
+    
+    // from sqale.xml
+    assertThat(rule.debtSubCharacteristic()).isEqualTo("COMPILER_RELATED_PORTABILITY");
+    DebtRemediationFunction remediationFunction = rule.debtRemediationFunction();
+    assertThat(remediationFunction).isNotNull();
+    assertThat(remediationFunction.type()).isEqualTo(Type.LINEAR_OFFSET);
+    assertThat(remediationFunction.coefficient()).isEqualTo("5min");
+    assertThat(remediationFunction.offset()).isEqualTo("10min");
   }
 }


### PR DESCRIPTION
Experimental: Add an option to add SQALE characteristics for external (other) rules. Like rules the user can add them in the configuration under C++ settings / (2) Code analysis.

close #467

@jmecosta, @Bertk and others: What are you thinking?
