### PR TITLE
inverted checks

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/FileRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/FileRegularExpressionCheck.java
@@ -51,7 +51,9 @@ import org.sonar.squidbridge.annotations.RuleTemplate;
 public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final String DEFAULT_MATCH_FILE_PATTERN = "";
+  private static final boolean DEFAULT_INVERT_FILE_PATTERN = false;
   private static final String DEFAULT_REGULAR_EXPRESSION = "";
+  private static final boolean DEFAULT_INVERT_REGULAR_EXPRESSION = false;
   private static final String DEFAULT_MESSAGE = "The regular expression matches this file";
 
   private Charset charset;
@@ -65,10 +67,22 @@ public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements C
   public String matchFilePattern = DEFAULT_MATCH_FILE_PATTERN;
 
   @RuleProperty(
+    key = "invertFilePattern",
+    description = "Invert file pattern comparison",
+    defaultValue = "" + DEFAULT_INVERT_FILE_PATTERN)
+  public boolean invertFilePattern = DEFAULT_INVERT_FILE_PATTERN;
+
+  @RuleProperty(
     key = "regularExpression",
     description = "The regular expression",
     defaultValue = DEFAULT_REGULAR_EXPRESSION)
   public String regularExpression = DEFAULT_REGULAR_EXPRESSION;
+
+  @RuleProperty(
+    key = "invertRegularExpression",
+    description = "Invert regular expression comparison",
+    defaultValue = "" + DEFAULT_INVERT_REGULAR_EXPRESSION)
+  public boolean invertRegularExpression = DEFAULT_INVERT_REGULAR_EXPRESSION;
 
   @RuleProperty(
     key = "message",
@@ -97,11 +111,11 @@ public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements C
   public void visitFile(AstNode fileNode) {
     if (fileNode != null) {
       try {
-        if (!matchFile()) {
+        if (!compare(invertFilePattern, matchFile())) {
           return;
         }
         Matcher matcher = pattern.matcher(fromFile(getContext().getFile()));
-        if (matcher.find()) {
+        if (compare(invertRegularExpression, matcher.find())) {
           getContext().createFileViolation(this, message);
         }
       } catch (Exception e) {
@@ -134,4 +148,7 @@ public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements C
     }
   }
 
+  private boolean compare(boolean invert, boolean condition) {
+    return invert ? !condition : condition;
+  }
 }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/XPathCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/XPathCheck.java
@@ -39,6 +39,7 @@ import org.sonar.squidbridge.annotations.RuleTemplate;
 public class XPathCheck extends AbstractXPathCheck<Grammar> {
 
   private static final String DEFAULT_MATCH_FILE_PATTERN = "";
+  private static final boolean DEFAULT_INVERT_FILE_PATTERN = false;
   private static final String DEFAULT_XPATH_QUERY = "";
   private static final String DEFAULT_MESSAGE = "The XPath expression matches this piece of code";
 
@@ -47,6 +48,12 @@ public class XPathCheck extends AbstractXPathCheck<Grammar> {
     description = "Ant-style matching patterns for path",
     defaultValue = DEFAULT_MATCH_FILE_PATTERN)
   public String matchFilePattern = DEFAULT_MATCH_FILE_PATTERN;
+
+  @RuleProperty(
+    key = "invertFilePattern",
+    description = "Invert file pattern comparison",
+    defaultValue = "" + DEFAULT_INVERT_FILE_PATTERN)
+  public boolean invertFilePattern = DEFAULT_INVERT_FILE_PATTERN;
 
   @RuleProperty(
     key = "xpathQuery",
@@ -77,7 +84,7 @@ public class XPathCheck extends AbstractXPathCheck<Grammar> {
       if (!matchFilePattern.isEmpty()) {
         WildcardPattern pattern = WildcardPattern.create(matchFilePattern);
         String path = PathUtils.sanitize(getContext().getFile().getPath());
-        if (!pattern.match(path)) {
+        if (!compare(invertFilePattern, pattern.match(path))) {
           return;
         }
       }
@@ -85,4 +92,7 @@ public class XPathCheck extends AbstractXPathCheck<Grammar> {
     }
   }
 
+  private boolean compare(boolean invert, boolean condition) {
+    return invert ? !condition : condition;
+  }
 }

--- a/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/FileRegularExpression.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/FileRegularExpression.html
@@ -6,6 +6,15 @@ Additional a Ant-style matching pattern for the path can be defined.
 <p>
 matchFilePattern allows Ant-style matching patterns for the path. If no matchFilePattern is defined all files are evaluated.
 </p>
+<p>
+invertFilePattern allows to invert the matching pattern comparison. If no 'matchFilePattern' is defined all files are evaluated.
+</p>
+<p>
+regularExpression to search for in the file. Any Java regular expression can be used.
+</p>
+<p>
+invertRegularExpression allows to invert the regular expression search of 'regularExpression'.
+</p>
 
 <p>
 Following rules are applied:

--- a/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/LineRegularExpression.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/LineRegularExpression.html
@@ -5,9 +5,18 @@ Additional a Ant-style matching pattern for the path can be defined.
 </p>
 
 <p>
-matchFilePattern allows Ant-style matching patterns for the path. If no matchFilePattern is defined all files are evaluated.
+matchFilePattern allows Ant-style matching patterns for the path. If no 'matchFilePattern' is defined all files are evaluated.
 </p>
-
+<p>
+invertFilePattern allows to invert the matching pattern comparison. If no 'matchFilePattern' is defined all files are evaluated.
+</p>
+<p>
+regularExpression to search for in line. Any Java regular expression can be used.
+</p>
+<p>
+invertRegularExpression allows to invert the regular expression search of 'regularExpression'.
+</p>
+    
 <p>
 Following rules are applied:
 </p>

--- a/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/XPath.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/c++/rules/cxx/XPath.html
@@ -14,6 +14,9 @@ Violations are created depending on the return value of the XPath expression. If
 <p>
 matchFilePattern allows Ant-style matching patterns for the path. If no matchFilePattern is defined all files are evaluated.
 </p>
+<p>
+invertFilePattern allows to invert the matching pattern comparison. If no 'matchFilePattern' is defined all files are evaluated.
+</p>
 
 <p>
 Following rules are applied:

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/FileRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/FileRegularExpressionCheckTest.java
@@ -45,6 +45,21 @@ public class FileRegularExpressionCheckTest {
   }
 
   @Test
+  public void fileRegExInvertWithoutFilePattern() {
+    FileRegularExpressionCheck check = new FileRegularExpressionCheck();
+    Charset charset = Charset.forName("UTF-8");
+    CxxConfiguration cxxConfig = new CxxConfiguration(charset);
+    check.regularExpression = "stdafx\\.h";
+    check.invertRegularExpression = true;
+    check.message = "Found no 'stdafx.h' in file!";
+
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/FileRegExInvert.cc"), cxxConfig, check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
   public void fileRegExCodingErrorActionReplace() {
     FileRegularExpressionCheck check = new FileRegularExpressionCheck();
     Charset charset = Charset.forName("US-ASCII");
@@ -68,6 +83,23 @@ public class FileRegularExpressionCheckTest {
     check.message = "Found '#include \"stdafx.h\"' in a .cc file!";
 
     SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/FileRegEx.cc"), cxxConfig, check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void fileRegExInvertWithFilePatternInvert() {
+    FileRegularExpressionCheck check = new FileRegularExpressionCheck();
+    Charset charset = Charset.forName("UTF-8");
+    CxxConfiguration cxxConfig = new CxxConfiguration(charset);
+    check.matchFilePattern = "/**/*.h"; // all files with not .h file extension
+    check.invertFilePattern = true;
+    check.regularExpression = "#include\\s+\"stdafx\\.h\"";
+    check.invertRegularExpression = true;
+    check.message = "Found no '#include \"stdafx.h\"' in a file with not '.h' file extension!";
+
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/FileRegExInvert.cc"), cxxConfig, check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().withMessage(check.message)
       .noMore();

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/LineRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/LineRegularExpressionCheckTest.java
@@ -42,11 +42,39 @@ public class LineRegularExpressionCheckTest {
   }
 
   @Test
+  public void lineRegExInvertWithoutFilePattern() {
+    LineRegularExpressionCheck check = new LineRegularExpressionCheck();
+    check.regularExpression = "//.*";
+    check.invertRegularExpression = true;
+    check.message = "Found no comment in the line!";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/LineRegExInvert.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(3).withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
   public void lineRegExWithFilePattern1() {
     LineRegularExpressionCheck check = new LineRegularExpressionCheck();
     check.matchFilePattern = "/**/*.cc"; // all files with .cc file extension
     check.regularExpression = "#include\\s+\"stdafx\\.h\"";
     check.message = "Found '#include \"stdafx.h\"' in line in a .cc file!";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/LineRegEx.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(2).withMessage(check.message)
+      .next().atLine(3).withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void lineRegExWithFilePatternInvert() {
+    LineRegularExpressionCheck check = new LineRegularExpressionCheck();
+    check.matchFilePattern = "/**/*.xx"; // all files with not .xx file extension
+    check.invertFilePattern = true;
+    check.regularExpression = "#include\\s+\"stdafx\\.h\"";
+    check.message = "Found '#include \"stdafx.h\"' in line in a not .xx file!";
 
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/LineRegEx.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/XPathCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/XPathCheckTest.java
@@ -78,4 +78,17 @@ public class XPathCheckTest {
       .noMore();
   }
 
+  @Test
+  public void xpathWithFilePatternInvert() {
+    XPathCheck check = new XPathCheck();
+    check.matchFilePattern = "/**/*.xxx"; // all files with not .xxx file extension
+    check.invertFilePattern = true;
+    check.xpathQuery = "//declaration";
+    check.message = "Avoid declarations!! ";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/xpath.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(1).withMessage(check.message)
+      .noMore();
+  }
 }

--- a/cxx-checks/src/test/resources/checks/FileRegExInvert.cc
+++ b/cxx-checks/src/test/resources/checks/FileRegExInvert.cc
@@ -1,0 +1,4 @@
+// Comment äöüß Copyright ©
+int i;
+void func() {}
+

--- a/cxx-checks/src/test/resources/checks/LineRegExInvert.cc
+++ b/cxx-checks/src/test/resources/checks/LineRegExInvert.cc
@@ -1,0 +1,5 @@
+// Comment
+#include "stdafx.h" // Comment
+int i;
+void func() {} // Comment
+// EOF


### PR DESCRIPTION
add the possibility to invert the search criteria for Ant-style file pattern and regular expressions for the checks XPathCheck, FileRegularExpression and LineRegularExpression.
add additional unit tests
update HTML documentation
close #534