### PR TITLE
remove default report paths

### DIFF
--- a/integration-tests/features/multimodule_analysis.feature
+++ b/integration-tests/features/multimodule_analysis.feature
@@ -15,6 +15,7 @@ Feature: cpp-multimodule-project
               .*WARN  - the include root '.*' doesn't exist
               .*WARN  - .* cannot find the sources for .*
               .*WARN  - SCM provider autodetection failed.*
+              .*WARN.*Cannot find a report for '.*'
               """
           AND the following metrics have following values:
                | metric                   | value |

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -12,6 +12,7 @@ Feature: Smoketest
               .*WARN.*cannot find the sources for '#include <gtest/gtest\.h>'
               .*WARN.*cannot find the sources for '#include <iostream>'
               .*WARN.*Cannot find the file '.*component_XXX.cc', skipping violations
+              .*WARN.*Cannot find a report for '.*'
               .*WARN.*Already created edge from 'src/cli/main.cc'.*
               """
           AND the following metrics have following values:

--- a/integration-tests/features/test_create_rules_and_bullseye_import.feature
+++ b/integration-tests/features/test_create_rules_and_bullseye_import.feature
@@ -20,6 +20,7 @@ Feature: GoogleTestWithBullseyeAndVsProject
               .*WARN.*to create a dependency with 'PathHandling/PathHandle.h'
               .*WARN.*cannot find the sources for '#include <unistd\.h>'
               .*WARN.*Cannot find the file '.*gtestmock.1.7.2.*', ignoring coverage measures
+              .*WARN.*Cannot find a report for '.*'
               .*WARN.*cannot find the sources for '#include.* 
               
               """

--- a/integration-tests/features/test_execution_statistics.feature
+++ b/integration-tests/features/test_execution_statistics.feature
@@ -184,6 +184,7 @@ Feature: Providing test execution numbers
               .*WARN.*cannot find the sources for '#include <gtest/gtest\.h>'
               .*WARN.*cannot find the sources for '#include <unistd\.h>'
               .*WARN.*The report.*seems to be empty, ignoring\.
+              .*WARN.*Cannot find a report for '.*'
               """
           AND the following metrics have following values:
               | metric               | value |

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CompilerParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CompilerParser.java
@@ -44,12 +44,6 @@ public interface CompilerParser {
     String rulesRepositoryKey();
 
     /**
-     * Get the default report path.
-     * @return
-     */
-    String defaultReportPath();
-
-    /**
      * Get the default regexp used to parse warning messages.
      * @return The default regexp.
      */

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerGccParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerGccParser.java
@@ -40,7 +40,6 @@ public class CxxCompilerGccParser implements CompilerParser{
   // sample regex: "^.*[\\\\,/](?<filename>.*)\\((?<line>[0-9]+)\\)\\x20:\\x20warning\\x20(?<id>C\\d\\d\\d\\d):(?<message>.*)$";
   // get value with e.g. scanner.match().group("filename");
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
-  public static final String DEFAULT_REPORT_PATH = "compiler-reports/build.log";
 
   /**
    * {@inheritDoc}
@@ -54,13 +53,6 @@ public class CxxCompilerGccParser implements CompilerParser{
    */
   public String rulesRepositoryKey() {
     return CxxCompilerGccRuleRepository.KEY;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   /**

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
@@ -96,11 +96,6 @@ public class CxxCompilerSensor extends CxxReportSensor {
     return REPORT_PATH_KEY;
   }
 
-  @Override
-  protected String defaultReportPath() {
-    return getCompilerParser().defaultReportPath();
-  }
-
   /**
    * Get string property from configuration.
    * If the string is not set or empty, return the default value.

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerVcParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerVcParser.java
@@ -40,7 +40,6 @@ public class CxxCompilerVcParser implements CompilerParser {
   // sample regex for VS2012/2013: "^.*>(?<filename>.*)\\((?<line>\\d+)\\):\\x20warning\\x20(?<id>C\\d+):(?<message>.*)$";
   // get value with e.g. scanner.match().group("filename");
   public static final String DEFAULT_CHARSET_DEF = "UTF-8"; // use "UTF-16" for VS2010 build log
-  public static final String DEFAULT_REPORT_PATH = "compiler-reports/BuildLog.htm";
 
   /**
    * {@inheritDoc}
@@ -54,13 +53,6 @@ public class CxxCompilerVcParser implements CompilerParser {
    */
   public String rulesRepositoryKey() {
     return CxxCompilerVcRuleRepository.KEY;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   /**

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
@@ -44,7 +44,6 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
  */
 public class CxxCppCheckSensor extends CxxReportSensor {
   public static final String REPORT_PATH_KEY = "sonar.cxx.cppcheck.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "cppcheck-reports/cppcheck-result-*.xml";
 
   private final RulesProfile profile;
   private final List<CppcheckParser> parsers = new LinkedList<CppcheckParser>();
@@ -72,11 +71,6 @@ public class CxxCppCheckSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
@@ -45,7 +45,6 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 public class CxxExternalRulesSensor extends CxxReportSensor {
 
   public static final String REPORT_PATH_KEY = "sonar.cxx.other.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "externalrules-reports/externalrules-result-*.xml";
   private final RulesProfile profile;
 
   /**
@@ -68,11 +67,6 @@ public class CxxExternalRulesSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
@@ -52,7 +52,6 @@ import org.sonar.api.batch.bootstrap.ProjectReactor;
 public class CxxPCLintSensor extends CxxReportSensor {
 
   public static final String REPORT_PATH_KEY = "sonar.cxx.pclint.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "pclint-reports/pclint-result-*.xml";
   private final RulesProfile profile;
 
   /**
@@ -75,11 +74,6 @@ public class CxxPCLintSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
@@ -41,7 +41,6 @@ import org.sonar.api.batch.bootstrap.ProjectReactor;
 public final class CxxRatsSensor extends CxxReportSensor {
   private static final String MISSING_RATS_TYPE = "fixed size global buffer";
   public static final String REPORT_PATH_KEY = "sonar.cxx.rats.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "rats-reports/rats-result-*.xml";
   private RulesProfile profile;
 
   /**
@@ -64,11 +63,6 @@ public final class CxxRatsSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -165,7 +165,7 @@ public final class CxxSquidSensor implements Sensor {
     
     String filePaths = conf.getString(CxxCompilerSensor.REPORT_PATH_KEY);    
     if (filePaths != null && !"".equals(filePaths)) {
-      List<File> reports = CxxReportSensor.getReports(conf, fs.baseDir().getPath(), CxxCompilerSensor.REPORT_PATH_KEY, "");
+      List<File> reports = CxxReportSensor.getReports(conf, fs.baseDir().getPath(), "", CxxCompilerSensor.REPORT_PATH_KEY);
       cxxConf.setCompilationPropertiesWithBuildLog(reports,
                                                    conf.getString(CxxCompilerSensor.PARSER_KEY_DEF),
                                                    conf.getString(CxxCompilerSensor.REPORT_CHARSET_DEF));

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
@@ -38,7 +38,6 @@ import org.sonar.api.batch.bootstrap.ProjectReactor;
  */
 public class CxxValgrindSensor extends CxxReportSensor {
   public static final String REPORT_PATH_KEY = "sonar.cxx.valgrind.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "valgrind-reports/valgrind-result-*.xml";
   private RulesProfile profile;
 
   /**
@@ -61,11 +60,6 @@ public class CxxValgrindSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
@@ -41,7 +41,6 @@ import org.sonar.plugins.cxx.utils.EmptyReportException;
  */
 public class CxxVeraxxSensor extends CxxReportSensor {
   public static final String REPORT_PATH_KEY = "sonar.cxx.vera.reportPath";
-  private static final String DEFAULT_REPORT_PATH = "vera++-reports/vera++-result-*.xml";
   private RulesProfile profile;
 
   /**
@@ -64,11 +63,6 @@ public class CxxVeraxxSensor extends CxxReportSensor {
   @Override
   protected String reportPathKey() {
     return REPORT_PATH_KEY;
-  }
-
-  @Override
-  protected String defaultReportPath() {
-    return DEFAULT_REPORT_PATH;
   }
 
   @Override

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensorTest.java
@@ -39,22 +39,14 @@ import org.sonar.api.resources.File;
 import org.sonar.api.resources.Project;
 import org.sonar.plugins.cxx.TestUtils;
 
-import org.sonar.api.batch.bootstrap.ProjectReactor;
 public class CxxCompilerSensorTest {
+
   private SensorContext context;
   private Project project;
   private FileSystem fs;
   private RulesProfile profile;
   private Issuable issuable;
   private ResourcePerspectives perspectives;
-  
-  private CxxCompilerSensor createSensor(String parser, String encoding)
-  {
-      Settings settings = new Settings();
-      settings.setProperty("sonar.cxx.compiler.parser", parser);
-      settings.setProperty("sonar.cxx.compiler.charset", encoding);
-      return new CxxCompilerSensor(perspectives, settings, fs, profile, TestUtils.mockReactor());
-  }
 
   @Before
   public void setUp() {
@@ -70,18 +62,26 @@ public class CxxCompilerSensorTest {
 
   @Test
   public void shouldReportACorrectVcViolations() {
-    CxxCompilerSensor sensor = createSensor(CxxCompilerVcParser.KEY, "UTF-16");
+    Settings settings = new Settings();
+    settings.setProperty("sonar.cxx.compiler.parser", CxxCompilerVcParser.KEY);
+    settings.setProperty(CxxCompilerSensor.REPORT_PATH_KEY, "compiler-reports/BuildLog.htm");
+    settings.setProperty(CxxCompilerSensor.REPORT_CHARSET_DEF, "UTF-16");
+    CxxCompilerSensor sensor = new CxxCompilerSensor(perspectives, settings, fs, profile, TestUtils.mockReactor());
     sensor.analyse(project, context);
     verify(issuable, times(9)).addIssue(any(Issue.class));
   }
 
   @Test
   public void shouldReportCorrectGccViolations() {
-    CxxCompilerSensor sensor = createSensor(CxxCompilerGccParser.KEY, "UTF-8");
+    Settings settings = new Settings();
+    settings.setProperty("sonar.cxx.compiler.parser", CxxCompilerGccParser.KEY);
+    settings.setProperty(CxxCompilerSensor.REPORT_PATH_KEY, "compiler-reports/build.log");
+    settings.setProperty(CxxCompilerSensor.REPORT_CHARSET_DEF, "UTF-8");
+    CxxCompilerSensor sensor = new CxxCompilerSensor(perspectives, settings, fs, profile, TestUtils.mockReactor());
     sensor.analyse(project, context);
     verify(issuable, times(4)).addIssue(any(Issue.class));
   }
-  
+
   @Test
   public void shouldReportBCorrectVcViolations() {
     Settings settings = new Settings();
@@ -93,6 +93,5 @@ public class CxxCompilerSensorTest {
     sensor.analyse(project, context);
     verify(issuable, times(9)).addIssue(any(Issue.class));
   }
-
 
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
@@ -70,6 +70,8 @@ public class CxxCppCheckSensorTest {
 
   @Test
   public void shouldReportCorrectViolations() {
+    settings.setProperty(CxxCppCheckSensor.REPORT_PATH_KEY,
+      "cppcheck-reports/cppcheck-result-*.xml");    
     sensor.analyse(project, context);
     verify(issuable, times(9)).addIssue(any(Issue.class));
   }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsSensorTest.java
@@ -40,6 +40,7 @@ import org.sonar.api.resources.Project;
 import org.sonar.plugins.cxx.TestUtils;
 
 public class CxxRatsSensorTest {
+
   private CxxRatsSensor sensor;
   private SensorContext context;
   private Project project;
@@ -53,7 +54,9 @@ public class CxxRatsSensorTest {
     project = TestUtils.mockProject();
     issuable = TestUtils.mockIssuable();
     perspectives = TestUtils.mockPerspectives(issuable);
-    sensor = new CxxRatsSensor(perspectives, new Settings(), fs, mock(RulesProfile.class), TestUtils.mockReactor());
+    Settings settings = new Settings();
+    settings.setProperty(CxxRatsSensor.REPORT_PATH_KEY, "rats-reports/rats-result-*.xml");
+    sensor = new CxxRatsSensor(perspectives, settings, fs, mock(RulesProfile.class), TestUtils.mockReactor());
     context = mock(SensorContext.class);
     File resourceMock = mock(File.class);
     when(context.getResource((File) anyObject())).thenReturn(resourceMock);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxReportSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxReportSensorTest.java
@@ -71,40 +71,46 @@ public class CxxReportSensorTest {
     new CxxReportSensorImpl(settings, fs, reactor);
   }
 
-
   @Test
-  public void getReports_shouldFindSomethingIfThere() {
-    List<File> reports = sensor.getReports(settings, baseDir.getPath(),
-        "", VALID_REPORT_PATH);
-    assertFound(reports);
-  }
-
-  @Test
-  public void getReports_shouldFindNothingIfNotThere() {
-    List<File> reports = sensor.getReports(new Settings(), baseDir.getPath(),
-        "", INVALID_REPORT_PATH);
-    assertNotFound(reports);
-  }
-
-  @Test
-  public void getReports_shouldUseConfigurationWithHigherPriority() {
-    // we'll detect this condition by passing something not existing as config property
-    // and something existing as default. The result is 'found nothing' because the
-    // config has been used
+  public void getReports_shouldFindNothingIfNoKey() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, INVALID_REPORT_PATH);
-
-    List<File> reports = sensor.getReports(settings, baseDir.getPath(),
-        REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH);
+    List<File> reports = sensor.getReports(settings, baseDir.getPath(), "",
+      "");
     assertNotFound(reports);
   }
 
   @Test
-  public void getReports_shouldFallbackToDefaultIfNothingConfigured() {
-    List<File> reports = sensor.getReports(settings, baseDir.getPath(),
-        REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH);
+  public void getReports_shouldFindNothingIfNoPath() {
+    settings.setProperty(REPORT_PATH_PROPERTY_KEY, "");
+    List<File> reports = sensor.getReports(settings, baseDir.getPath(), "",
+      REPORT_PATH_PROPERTY_KEY);
+    assertNotFound(reports);
+  }
+
+  @Test
+  public void getReports_shouldFindNothingIfInvalidPath() {
+    settings.setProperty(REPORT_PATH_PROPERTY_KEY, INVALID_REPORT_PATH);
+    List<File> reports = sensor.getReports(settings, baseDir.getPath(), "",
+      REPORT_PATH_PROPERTY_KEY);
+    assertNotFound(reports);
+  }
+
+  @Test
+  public void getReports_shouldFindSomethingBaseDir1() {
+    settings.setProperty(REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH);
+    List<File> reports = sensor.getReports(settings, baseDir.getPath(), "",
+      REPORT_PATH_PROPERTY_KEY);
     assertFound(reports);
   }
 
+  @Test
+  public void getReports_shouldFindSomethingBaseDir2() {
+    settings.setProperty(REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH);
+    List<File> reports = sensor.getReports(settings, baseDir.getPath()+"Invalid", baseDir.getPath(),
+      REPORT_PATH_PROPERTY_KEY);
+    assertFound(reports);
+  }
+  
   @Test
   public void savesACorrectLineLevelViolation() {
     // assert(sensor.saveViolation(??, ??, rulerepokey, "existingfile",

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxReportSensor_getReports_Test.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxReportSensor_getReports_Test.java
@@ -91,7 +91,7 @@ public class CxxReportSensor_getReports_Test {
       setupExample(allpaths);
       settings.setProperty(property, pattern);
 
-      reports = sensor.getReports(settings, base.getRoot().getPath(), property, "");
+      reports = sensor.getReports(settings, base.getRoot().getPath(), "", property);
 
       assertMatch(reports, match);
       deleteExample(base.getRoot());

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensorTest.java
@@ -52,7 +52,9 @@ public class CxxVeraxxSensorTest {
     project = TestUtils.mockProject();
     issuable = TestUtils.mockIssuable();
     perspectives = TestUtils.mockPerspectives(issuable);
-    sensor = new CxxVeraxxSensor(perspectives, new Settings(), fs, mock(RulesProfile.class), TestUtils.mockReactor());
+    Settings settings = new Settings();
+    settings.setProperty(CxxVeraxxSensor.REPORT_PATH_KEY, "vera++-reports/vera++-result-*.xml");
+    sensor = new CxxVeraxxSensor(perspectives, settings, fs, mock(RulesProfile.class), TestUtils.mockReactor());
     context = mock(SensorContext.class);
     org.sonar.api.resources.File resourceMock = mock(org.sonar.api.resources.File.class);
     when(context.getResource((org.sonar.api.resources.File) anyObject())).thenReturn(resourceMock);


### PR DESCRIPTION
* remove  DEFAULT_REPORT_PATH from all sensors
* don't execute sensor if key does not exist in configuration (exception is coverage: sensor set coverage to 0 in this case)
* improve error messages and warnings in case of wrong report settings or access problems
* close #267
* close #331