### PR TITLE
Support for friend declaration API documentation

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -190,6 +190,11 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
             return;
         }
 
+        // ignore friend declarations
+        if (isFriendDeclaration(declaratorList)) {
+            return;
+        }
+
         AstNode declaration = declaratorList
                 .getFirstAncestor(CxxGrammarImpl.declaration);
 
@@ -208,6 +213,36 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
                 visitDeclarator(declarator, declarator);
             }
         }
+    }
+
+    private boolean isFriendDeclaration(AstNode declaratorList) {
+        AstNode simpleDeclNode = declaratorList
+                .getFirstAncestor(CxxGrammarImpl.simpleDeclaration);
+
+        if (simpleDeclNode == null) {
+            LOG.warn("No simple declaration found for declarator list at {}",
+                    declaratorList.getTokenLine());
+            return false;
+        }
+
+        AstNode simpleDeclSpecifierSeq = simpleDeclNode
+                .getFirstChild(CxxGrammarImpl.simpleDeclSpecifierSeq);
+
+        if (simpleDeclSpecifierSeq == null) {
+            return false;
+        }
+
+        List<AstNode> declSpecifiers = simpleDeclSpecifierSeq
+                .getChildren(CxxGrammarImpl.declSpecifier);
+
+        for (AstNode declSpecifier : declSpecifiers) {
+            AstNode friendNode = declSpecifier.getFirstChild(CxxKeyword.FRIEND);
+            if (friendNode != null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void visitSingleDeclarator(AstNode declaration,

--- a/cxx-squid/src/test/resources/metrics/public_api.h
+++ b/cxx-squid/src/test/resources/metrics/public_api.h
@@ -35,6 +35,11 @@ public:
 	
 	int attr1, //!< attr1 doc 
 	attr2; ///< attr2 doc
+
+	// ignore friend declaration
+	template<typename S> friend S& operator<<(S&, A const&);
+
+	friend class friendClass;
 protected:
 	/**
 	 protectedMethod doc


### PR DESCRIPTION
Do not generate anymore violation for undocumented friend declaration in
public API.

Fix #576