### PR TITLE
Support defaulted/deleted methods API documentation

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
@@ -123,12 +123,12 @@ public class CxxPublicApiVisitorTest {
 
     @Test
     public void to_delete() {
-        testFile("src/test/resources/metrics/public_api.h", 40, 0, true);
+        testFile("src/test/resources/metrics/public_api.h", 41, 0, true);
     }
 
     @Test
     public void no_doc() {
-        testFile("src/test/resources/metrics/no_doc.h", 21, 21, true);
+        testFile("src/test/resources/metrics/no_doc.h", 22, 22, true);
     }
 
     @Test
@@ -175,6 +175,7 @@ public class CxxPublicApiVisitorTest {
 
         final Map<String, String> expectedIdCommentMap = new HashMap<String, String>();
 
+        expectedIdCommentMap.put("publicDefinedMethod", "publicDefinedMethod");
         expectedIdCommentMap.put("aliasDeclaration", "aliasDeclaration");
         expectedIdCommentMap.put("publicMethod", "publicMethod");
         expectedIdCommentMap.put("testStruct", "testStruct");

--- a/cxx-squid/src/test/resources/metrics/no_doc.h
+++ b/cxx-squid/src/test/resources/metrics/no_doc.h
@@ -23,6 +23,14 @@ public:
 	int inlineCommentedAttr; 
 
 	void inlinePublicMethod();
+
+	// ignore deleted methods
+	A(A const&) = delete;
+
+	// ignore defaulted methods
+	A& operator=(A const&) = default;
+
+	void publicDefinedMethod() { }
 	 
 protected:
 	virtual void protectedMethod();

--- a/cxx-squid/src/test/resources/metrics/public_api.h
+++ b/cxx-squid/src/test/resources/metrics/public_api.h
@@ -40,6 +40,17 @@ public:
 	template<typename S> friend S& operator<<(S&, A const&);
 
 	friend class friendClass;
+
+	// ignore deleted methods
+	A(A const&) = delete;
+
+	// ignore defaulted methods
+	A& operator=(A const&) = default;
+
+	/**
+	 * publicDefinedMethod comment
+	 */
+	void publicDefinedMethod() { }
 protected:
 	/**
 	 protectedMethod doc


### PR DESCRIPTION
Remove public API documentation violation generation for defaulted and
deleted methods.

Fix #558