### PR TITLE
fix for trailing return types

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -133,10 +133,11 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
   storageClassSpecifier,
   functionSpecifier,
-  typedefName,
+  typedefName,  
   typeSpecifier,
-  trailingTypeSpecifier,
   typeSpecifierSeq,
+  trailingTypeSpecifier,
+  trailingTypeSpecifierSeq,
   simpleTypeSpecifier,
   typeName,
   decltypeSpecifier,
@@ -820,6 +821,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         )
       );
 
+    b.rule(trailingTypeSpecifierSeq).is(b.oneOrMore(trailingTypeSpecifier), b.optional(attributeSpecifierSeq));
+     
     b.rule(trailingTypeSpecifier).is(
       b.firstOf(
         simpleTypeSpecifier,
@@ -1028,7 +1031,9 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
                                             b.optional(exceptionSpecification)
                                             );
 
-    b.rule(trailingReturnType).is("->", simpleTypeSpecifier);
+    b.rule(trailingReturnType).is(
+        b.sequence("->", b.oneOrMore(trailingTypeSpecifierSeq), b.optional(abstractDeclarator))
+    );
 
     b.rule(ptrOperator).is(
         b.firstOf(

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
@@ -135,16 +135,38 @@ public class DeclarationsTest extends ParserBaseTest {
     assertThat(p).matches("bool operator==(const lhs&, const rhs&);");
     assertThat(p).matches("bool operator==<B>(A const&, A const&);");
 
+    assertThat(p).matches("int foo();");
+    assertThat(p).matches("const int foo();");
+    assertThat(p).matches("int* foo();");
+    assertThat(p).matches("const int* foo();");
+    assertThat(p).matches("int& foo();");
+    assertThat(p).matches("const int& foo();");
+    assertThat(p).matches("long long foo();");
+    assertThat(p).matches("const long long foo();");
+    assertThat(p).matches("long long* foo();");
+    assertThat(p).matches("const long long* foo();");
+    assertThat(p).matches("long long& foo();");
+    assertThat(p).matches("const long long& foo();");    
+    assertThat(p).matches("MyClass foo();");
+    assertThat(p).matches("const MyClass foo();");
+    assertThat(p).matches("MyClass* foo();");
+    assertThat(p).matches("const MyClass* foo();");
+    assertThat(p).matches("MyClass* foo();");
+    assertThat(p).matches("const MyClass* foo();");
+    
+    assertThat(p).matches("extern int foo();");
+    
+    assertThat(p).matches("auto to_string(int value) -> int;");
+    assertThat(p).matches("auto to_string(int value) -> long long;");
     assertThat(p).matches("auto to_string(int value) -> std::string;");
     assertThat(p).matches("auto size() const -> std::size_t;");
     assertThat(p).matches("auto str() const;");
     assertThat(p).matches("auto equal_range(ForwardIterator first, ForwardIterator last, const Type& value) -> std::pair<ForwardIterator, ForwardIterator>;");
 
-//    assertThat(p).matches("int property;");
-//    assertThat(p).matches("int property = 0;");
-//  ToDo : make this work
-//  assertThat(p).matches("auto str() const -> const char*;");
-//  assertThat(p).matches("auto std::map::at(const key_type& key) -> mapped_type&;");
+    assertThat(p).matches("auto str() const -> const char*;");
+    assertThat(p).matches("auto std::map::at(const key_type& key) -> mapped_type&;");
+    assertThat(p).matches("auto f() -> int(*)[4];");
+    assertThat(p).matches("auto fpif(int) -> int(*)(int);");
 
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/LamdaExpressionsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/LamdaExpressionsTest.java
@@ -58,6 +58,7 @@ public class LamdaExpressionsTest extends ParserBaseTest {
     assertThat(p).matches("[&foo1,&foo2,&foo3] (int n, int y, int z) { }");
     assertThat(p).matches("[] () throw () { }");
     assertThat(p).matches("[] () -> int { return 1; }");
+    assertThat(p).matches("[] () -> long long { return 1; }");
     assertThat(p).matches("[] (const string& addr) { return addr.find( \".org\" ) != string::npos; }");
     assertThat(p).matches("[this] () { cout << _x; }");
     assertThat(p).matches("[] (int x, int y) -> int { return x + y; }");

--- a/cxx-squid/src/test/resources/parser/own/C++11/long-long-int.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++11/long-long-int.cc
@@ -7,6 +7,5 @@ void func2(long long int p) {}
 long long func3() { return 0; }
 long long int func4() { return 0; }
 
-//@todo
-//auto func5(long long p) -> long long { return 0; }
-//auto func6(long long int p) -> long long int { return 0; }
+auto func5(long long p) -> long long { return 0; }
+auto func6(long long int p) -> long long int { return 0; }


### PR DESCRIPTION
supporting also more complex cases now:
auto str() -> long long;
auto str() const -> const char*;
auto std::map::at(const key_type& key) -> mapped_type&;
auto f() -> int(*)[4];
auto fpif(int) -> int(*)(int);

close #561