### PR TITLE
non-type template parameters fix #573

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1510,10 +1510,10 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(templateId).is(
         b.firstOf(
             simpleTemplateId,
-            b.sequence(operatorFunctionId, "<", innerTemplateId, ">>"),
-            b.sequence(literalOperatorId, "<", innerTemplateId, ">>"),
             b.sequence(operatorFunctionId, "<", b.optional(templateArgumentList), ">"),
-            b.sequence(literalOperatorId, "<", b.optional(templateArgumentList), ">")
+            b.sequence(literalOperatorId, "<", b.optional(templateArgumentList), ">"),
+            b.sequence(operatorFunctionId, "<", innerTemplateId, ">>"),
+            b.sequence(literalOperatorId, "<", innerTemplateId, ">>")
         )
         );
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -64,6 +64,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   pseudoDestructorName,
   unaryExpression,
   unaryOperator,
+  binaryOperator,
   newExpression,
   newPlacement,
   newTypeId,
@@ -542,6 +543,9 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(unaryOperator).is(
       b.firstOf("*", "&", "+", "-", "!", "~")
       );
+
+    b.rule(binaryOperator).is(
+      b.firstOf("||", "&&", "&", "|", "^", "==", "!=", "<=", "<", ">=", ">", "<<", ">>", "*", "/", "+", "-", assignmentOperator));
 
     b.rule(newExpression).is(
       b.firstOf(

--- a/cxx-squid/src/test/resources/parser/own/declarations.cc
+++ b/cxx-squid/src/test/resources/parser/own/declarations.cc
@@ -26,6 +26,8 @@ std::pair<const char*, std::vector<long int>> longNewStyle;
 template<class T, class Compare = std::less<T>>
 class list
 {
+   typedef unsigned char byte;
+   using PatchMap = std::vector<std::pair<size_t, std::vector<byte>>>;
 };
 
 template <class T>
@@ -57,4 +59,14 @@ void issue_49 ()
   List<unsigned*> ld;
   static_cast<List<B>>(ld);
   vector<vector<vector<int>>> vvvi;
+}
+
+template<bool C, class T, class F> struct if_log2_             : F {};
+template<        class T, class F> struct if_log2_<true, T, F> : T {};
+template<unsigned A, unsigned R = 0> struct log2
+	: if_log2_<A == 1, std::integral_constant<int, R>, log2<A / 2, R + 1>> {};
+
+void issue_666 ()
+{
+  X<log2<23>::value> x5;
 }


### PR DESCRIPTION
Fixes #573 and adds some template constructs found in [openMSX](https://github.com/openMSX/openMSX) to the test suite.