### PR TITLE
Handle expressions in non-type template parameters, fix #573

### DIFF
--- a/cxx-squid/src/test/resources/parser/own/declarations.cc
+++ b/cxx-squid/src/test/resources/parser/own/declarations.cc
@@ -26,6 +26,8 @@ std::pair<const char*, std::vector<long int>> longNewStyle;
 template<class T, class Compare = std::less<T>>
 class list
 {
+   typedef unsigned char byte;
+   using PatchMap = std::vector<std::pair<size_t, std::vector<byte>>>;
 };
 
 template <class T>
@@ -57,4 +59,14 @@ void issue_49 ()
   List<unsigned*> ld;
   static_cast<List<B>>(ld);
   vector<vector<vector<int>>> vvvi;
+}
+
+template<bool C, class T, class F> struct if_log2_             : F {};
+template<        class T, class F> struct if_log2_<true, T, F> : T {};
+template<unsigned A, unsigned R = 0> struct log2
+	: if_log2_<A == 1, std::integral_constant<int, R>, log2<A / 2, R + 1>> {};
+
+void issue_666 ()
+{
+  X<log2<23>::value> x5;
 }


### PR DESCRIPTION
Squashed commit of the following:

commit e8459111b0f621b3165cbe5876e8b067867ffc78
Author: Arnold Metselaar <arnold.metselaar@planet.nl>
Date:   Sat Jul 25 00:14:17 2015 +0200

    Fix previous merge

    Define tokentype binaryOperator, which is used when looking ahead to see whether a templateId is plausible
    at a certain point in source code being parsed.

commit 91089d731b593e041963f21889f3b3900fc9d1da
Author: Arnold Metselaar <arnold.metselaar@cgi.com>
Date:   Fri Jul 24 14:00:23 2015 +0200

    Try template without ">>" first in rule for templateId.

commit e79246b8f4d2e154e6a6748d1a404d44428393bc
Author: Arnold Metselaar <arnold.metselaar@planet.nl>
Date:   Thu Jul 23 23:30:27 2015 +0200

    Improve parsing of nested templates,

    Use some heuristics to try to distinguish between tamplate arguments and inner template arguments.
    Added some lines to declarations.cc in the test suite.

    Conflicts:
    	cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java