### PR TITLE
stringinize with string prefix

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/StringLiteralsChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/StringLiteralsChannel.java
@@ -128,6 +128,8 @@ public class StringLiteralsChannel extends Channel<Lexer> {
       if (ch == 'u' && code.charAt(index) == '8') {
         index++;
       }
+      if (code.charAt(index) == ' ')
+        index++;
       ch = code.charAt(index);
     }
     if (ch == 'R') {

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
@@ -70,6 +70,7 @@ public enum CppGrammar implements GrammarRuleKey {
   multiplicativeExpression,
   additiveExpression,
   shiftExpression,
+  stringPrefix,
   relationalExpression,
   equalityExpression,
   andExpression,
@@ -161,7 +162,7 @@ public enum CppGrammar implements GrammarRuleKey {
         b.oneOrMore(
         b.firstOf(
             "##",
-            "#",
+            b.sequence(b.optional(stringPrefix),"#"),
             ppToken
         )
         )
@@ -169,6 +170,7 @@ public enum CppGrammar implements GrammarRuleKey {
 
     b.rule(parameterList).is(IDENTIFIER, b.zeroOrMore(b.zeroOrMore(WS), ",", b.zeroOrMore(WS), IDENTIFIER, b.nextNot(b.sequence(b.zeroOrMore(WS), "..."))));
     b.rule(argumentList).is(argument, b.zeroOrMore(b.zeroOrMore(WS), ",", b.zeroOrMore(WS), argument));
+    b.rule(stringPrefix).is(b.firstOf("L", "u8", "u", "U"));
 
     b.rule(argument).is(
         b.firstOf(

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
@@ -145,6 +145,10 @@ public class CppGrammarTest {
     assertThat(p).matches("");
     assertThat(p).matches("ppToken");
     assertThat(p).matches("#ppToken");
+    assertThat(p).matches("L#ppToken");
+    assertThat(p).matches("u8#ppToken");
+    assertThat(p).matches("u#ppToken");
+    assertThat(p).matches("U#ppToken");
     assertThat(p).matches("ppToken ## ppToken");
   }
 


### PR DESCRIPTION
The preprocessor will not identify an operator if a string prefix is used and this will create parser errors. 
This PR enhances the preprocessor to accept e.g. 'L#' as operator.


