### PR TITLE
Treat relative paths in Cobertura reports as relative to the project …

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -39,13 +39,18 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class BullseyeParser implements CoverageParser {
+public class BullseyeParser extends CoverageParserBase implements CoverageParser {
 
   private String prevLine;
   private int totaldecisions;
   private int totalcovereddecisions;
   private int totalconditions;
   private int totalcoveredconditions;
+
+  public BullseyeParser(final String baseDir)
+  {
+    super(baseDir);
+  }
 
   /**
    * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -39,7 +39,7 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class BullseyeParser extends CoverageParserBase implements CoverageParser {
+public class BullseyeParser extends CxxCoverageParser {
 
   private String prevLine;
   private int totaldecisions;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
@@ -36,7 +36,7 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class CoberturaParser extends CoverageParserBase implements CoverageParser {
+public class CoberturaParser extends CxxCoverageParser {
 
   public CoberturaParser(final String baseDir)
   {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
@@ -37,6 +37,14 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
  * {@inheritDoc}
  */
 public class CoberturaParser implements CoverageParser {
+
+  private final String baseDir;
+
+  public CoberturaParser(final String baseDir)
+  {
+    this.baseDir = baseDir;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -69,7 +77,7 @@ public class CoberturaParser implements CoverageParser {
       throws XMLStreamException
   {
     while (clazz.getNext() != null) {
-      String normalPath = CxxUtils.normalizePath(clazz.getAttrValue("filename"));
+      String normalPath = CxxUtils.normalizePathFull(clazz.getAttrValue("filename"), baseDir);
       if(normalPath != null){
         CoverageMeasuresBuilder builder = coverageData.get(normalPath);
         if (builder == null) {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
@@ -36,13 +36,11 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class CoberturaParser implements CoverageParser {
-
-  private final String baseDir;
+public class CoberturaParser extends CoverageParserBase implements CoverageParser {
 
   public CoberturaParser(final String baseDir)
   {
-    this.baseDir = baseDir;
+    super(baseDir);
   }
 
   /**

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoverageParserBase.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoverageParserBase.java
@@ -1,0 +1,33 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.coverage;
+
+/**
+ * The base class for coverage report parsers
+ */
+public class CoverageParserBase {
+
+    protected final String baseDir;
+
+    CoverageParserBase(final String baseDir)
+    {
+        this.baseDir = baseDir;
+    }
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageParser.java
@@ -22,11 +22,11 @@ package org.sonar.plugins.cxx.coverage;
 /**
  * The base class for coverage report parsers
  */
-public class CoverageParserBase {
+public abstract class CxxCoverageParser implements CoverageParser {
 
     protected final String baseDir;
 
-    CoverageParserBase(final String baseDir)
+    CxxCoverageParser(final String baseDir)
     {
         this.baseDir = baseDir;
     }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -63,9 +63,10 @@ public class CxxCoverageSensor extends CxxReportSensor {
     super(settings, fs, reactor);
 
     this.reactor = reactor;
-    parsers.add(new CoberturaParser(fs.baseDir().getAbsolutePath()));
-    parsers.add(new BullseyeParser());
-    parsers.add(new VisualStudioParser());
+    final String baseDir = fs.baseDir().getAbsolutePath();
+    parsers.add(new CoberturaParser(baseDir));
+    parsers.add(new BullseyeParser(baseDir));
+    parsers.add(new VisualStudioParser(baseDir));
   }
 
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -53,7 +53,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
   public static final String OVERALL_REPORT_PATH_KEY = "sonar.cxx.coverage.overallReportPath";
   public static final String FORCE_ZERO_COVERAGE_KEY = "sonar.cxx.coverage.forceZeroCoverage";
 
-  private static List<CoverageParser> parsers = new LinkedList<CoverageParser>();
+  private List<CoverageParser> parsers = new LinkedList<CoverageParser>();
     private final ProjectReactor reactor;
 
   /**
@@ -63,7 +63,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
     super(settings, fs, reactor);
 
     this.reactor = reactor;
-    parsers.add(new CoberturaParser());
+    parsers.add(new CoberturaParser(fs.baseDir().getAbsolutePath()));
     parsers.add(new BullseyeParser());
     parsers.add(new VisualStudioParser());
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
@@ -35,7 +35,12 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class VisualStudioParser implements CoverageParser {
+public class VisualStudioParser extends CoverageParserBase implements CoverageParser {
+
+  public VisualStudioParser(final String baseDir)
+  {
+    super(baseDir);
+  }
 
   /**
    * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
@@ -35,7 +35,7 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
 /**
  * {@inheritDoc}
  */
-public class VisualStudioParser extends CoverageParserBase implements CoverageParser {
+public class VisualStudioParser extends CxxCoverageParser {
 
   public VisualStudioParser(final String baseDir)
   {


### PR DESCRIPTION
…base directory as opposed to the current directory.

This is intended to address #426.  That issue is currently marked closed but it is not fixed I've requested that it be reopened.