### PR TITLE
adjustable forceZeroCoverage

### DIFF
--- a/integration-tests/features/importing_coverage.feature
+++ b/integration-tests/features/importing_coverage.feature
@@ -65,7 +65,7 @@ Feature: Importing coverage data
 
   Scenario: Zeroing coverage measures without importing reports
 
-      If we dont pass coverage reports *and* request zeroing untouched
+      If we don't pass coverage reports *and* request zeroing untouched
       files at the same time, all coverage measures, except the branch
       ones, should be 'zero'. The branch coverage measures remain 'None',
       since its currently ignored by the 'force zero...'
@@ -73,12 +73,19 @@ Feature: Importing coverage data
 
       GIVEN the project "coverage_project"
 
-      WHEN I run "sonar-runner -Dsonar.cxx.coverage.forceZeroCoverage=True"
+      WHEN I run sonar-runner with following options:
+          """
+          -Dsonar.cxx.coverage.reportPath=dummy.xml
+          -Dsonar.cxx.coverage.itReportPath=dummy.xml
+          -Dsonar.cxx.coverage.overallReportPath=dummy.xml
+          -Dsonar.cxx.coverage.forceZeroCoverage=True
+          """
 
       THEN the analysis finishes successfully
           AND the analysis log contains no error/warning messages except those matching:
               """
               .*WARN.*cannot find the sources for '#include <iostream>'
+              .*WARN.*Cannot find a report for '.*'
               """
           AND the following metrics have following values:
               | metric                  | value |

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -48,7 +48,9 @@ import org.sonar.plugins.cxx.utils.CxxUtils;
  * {@inheritDoc}
  */
 public class CxxCoverageSensor extends CxxReportSensor {
+
   private enum CoverageType {
+
     UT_COVERAGE, IT_COVERAGE, OVERALL_COVERAGE
   }
 
@@ -57,8 +59,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
   public static final String OVERALL_REPORT_PATH_KEY = "sonar.cxx.coverage.overallReportPath";
   public static final String FORCE_ZERO_COVERAGE_KEY = "sonar.cxx.coverage.forceZeroCoverage";
 
-  private List<CoverageParser> parsers = new LinkedList<CoverageParser>();
-    private final ProjectReactor reactor;
+  private List<CoverageParser> parsers = new LinkedList<>();
+  private final ProjectReactor reactor;
 
   /**
    * {@inheritDoc}
@@ -77,12 +79,11 @@ public class CxxCoverageSensor extends CxxReportSensor {
   public boolean shouldExecuteOnProject(Project project) {
     return fs.hasFiles(fs.predicates().hasLanguage(CxxLanguage.KEY))
       && (isForceZeroCoverageActivated()
-          || conf.hasKey(REPORT_PATH_KEY)
-          || conf.hasKey(IT_REPORT_PATH_KEY)
-          || conf.hasKey(OVERALL_REPORT_PATH_KEY)
-      );
+      || conf.hasKey(REPORT_PATH_KEY)
+      || conf.hasKey(IT_REPORT_PATH_KEY)
+      || conf.hasKey(OVERALL_REPORT_PATH_KEY));
   }
-  
+
   /**
    * {@inheritDoc}
    */
@@ -130,8 +131,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
   }
 
   private Map<String, CoverageMeasuresBuilder> processReports(final Project project, final SensorContext context, List<File> reports) {
-    Map<String, CoverageMeasuresBuilder> measuresTotal = new HashMap<String, CoverageMeasuresBuilder>();
-    Map<String, CoverageMeasuresBuilder> measuresForReport = new HashMap<String, CoverageMeasuresBuilder>();
+    Map<String, CoverageMeasuresBuilder> measuresTotal = new HashMap<>();
+    Map<String, CoverageMeasuresBuilder> measuresForReport = new HashMap<>();
 
     for (File report : reports) {
       CxxUtils.LOG.info("Processing report '{}'", report);
@@ -195,16 +196,22 @@ public class CxxCoverageSensor extends CxxReportSensor {
     for (InputFile inputFile : inputFiles) {
       String filePath = CxxUtils.normalizePath(inputFile.absolutePath());
 
-      if (coverageMeasures == null || coverageMeasures.get(filePath) == null) {
-        saveZeroValueForResource(inputFile, filePath, context, CoverageType.UT_COVERAGE);
+      if (conf.hasKey(REPORT_PATH_KEY)) {
+        if (coverageMeasures == null || coverageMeasures.get(filePath) == null) {
+          saveZeroValueForResource(inputFile, filePath, context, CoverageType.UT_COVERAGE);
+        }
       }
 
-      if (itCoverageMeasures == null || itCoverageMeasures.get(filePath) == null) {
-        saveZeroValueForResource(inputFile, filePath, context, CoverageType.IT_COVERAGE);
+      if (conf.hasKey(IT_REPORT_PATH_KEY)) {
+        if (itCoverageMeasures == null || itCoverageMeasures.get(filePath) == null) {
+          saveZeroValueForResource(inputFile, filePath, context, CoverageType.IT_COVERAGE);
+        }
       }
 
-      if (overallCoverageMeasures == null || overallCoverageMeasures.get(filePath) == null) {
-        saveZeroValueForResource(inputFile, filePath, context, CoverageType.OVERALL_COVERAGE);
+      if (conf.hasKey(OVERALL_REPORT_PATH_KEY)) {
+        if (overallCoverageMeasures == null || overallCoverageMeasures.get(filePath) == null) {
+          saveZeroValueForResource(inputFile, filePath, context, CoverageType.OVERALL_COVERAGE);
+        }
       }
     }
   }


### PR DESCRIPTION
Depend on which key (sonar.cxx.coverage.reportPath, sonar.cxx.coverage.itReportPath, sonar.cxx.coverage.overallReportPath) is defined in the sonar-project.properties file.

Example 1: Force forceZeroCoverage for Unit Tests only (other keys are not defined)
   sonar.cxx.coverage.forceZeroCoverage=true
   sonar.cxx.coverage.reportPath=reports/coverage-*.xml

Example 2: Force forceZeroCoverage for Unit Tests and Integration Tests
   sonar.cxx.coverage.forceZeroCoverage=true
   sonar.cxx.coverage.reportPath=reports/coverage-*.xml
   sonar.cxx.coverage.itReportPath=

close #633