### PR TITLE
Fix cpplint's NOLINT() with new rule names

### DIFF
--- a/sonar-cxx-plugin/src/tools/cpplint_createrules.py
+++ b/sonar-cxx-plugin/src/tools/cpplint_createrules.py
@@ -31,6 +31,14 @@ def WriteUpdateFile(filename):
     global _FILE_LINES
     filetowrite = open(filename, 'w')   
     for linei in _FILE_LINES:                   
+        if linei.startswith('        if category in _ERROR_CATEGORIES:'):
+            filetowrite.write('        for value in _ERROR_CATEGORIES:\n')
+            filetowrite.write('          if category.startswith(value):\n')
+            filetowrite.write('            category = value\n')
+        if linei.startswith('  return (linenum in _error_suppressions.get(category, set()) or'):
+            filetowrite.write('  for key in _error_suppressions.keys():\n')
+            filetowrite.write('    if category.startswith(key):\n')
+            filetowrite.write('      category = key\n')
         filetowrite.write(linei)
                                                         
     filetowrite.close()


### PR DESCRIPTION
NOLINT() only supports original rules list from _ERROR_CATEGORIES
but that list was left unmodified by cpplint_creatrules.py script.
This meant that any existing code that developers marked as false
positives using NOLINT method began reporting errors when switching to
modified cpplint and also it was impossible to re-mark using new rule names.

This modifies NOLINT() behavior to work like cpplint's --filter option
which masks any rule that starts with specified pattern.

This allows, for example, "// NOLINT(build/c++11)" to mask build/c++11
rule from non-modified cpplint as well as build/c++11-0 in modified
cpplint.