### PR TITLE
change paths in report so they dont randomly clash with folders that exist in e drive

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.cxx.coverage;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -168,8 +169,9 @@ public class CxxCoverageSensor extends CxxReportSensor {
       String filePath = entry.getKey();
       InputFile cxxFile = fs.inputFile(fs.predicates().hasPath(filePath));
       if (cxxFile != null) {
-        CxxUtils.LOG.debug("Saving coverage measures for file '{}'", filePath);
-        for (Measure measure : entry.getValue().createMeasures()) {
+        Collection<Measure> measures = entry.getValue().createMeasures();
+        CxxUtils.LOG.debug("Saving '{}' coverage measures for file '{}'", measures.size(), filePath);
+        for (Measure measure : measures) {
           switch (ctype) {
             case IT_COVERAGE:
               measure = convertToItMeasure(measure);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxBullseyeCoverageSensorTest.java
@@ -98,10 +98,10 @@ public class CxxBullseyeCoverageSensorTest {
     Settings settings = new Settings();
     if (TestUtils.isWindows()) {
       settings.setProperty(CxxCoverageSensor.REPORT_PATH_KEY, "coverage-reports/bullseye/bullseye-coverage-report-data-in-root-node-win.xml");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test/anotherincludeattop.h");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test/test/test.c");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test/test2/test2.c");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test/main.c");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas/anotherincludeattop.h");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas/test/test.c");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas/test2/test2.c");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas/main.c");
     } else {
       settings.setProperty(CxxCoverageSensor.REPORT_PATH_KEY, "coverage-reports/bullseye/bullseye-coverage-report-data-in-root-node-linux.xml");
       TestUtils.addInputFile(fs, perspectives, issuable, "/e/test/anotherincludeattop.h");
@@ -120,8 +120,8 @@ public class CxxBullseyeCoverageSensorTest {
     if (TestUtils.isWindows()) {
       settings.setProperty(CxxCoverageSensor.REPORT_PATH_KEY, "coverage-reports/bullseye/bullseye-coverage-drive-letter-without-slash-win.xml");
       TestUtils.addInputFile(fs, perspectives, issuable, "e:/main.c");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test/test.c");
-      TestUtils.addInputFile(fs, perspectives, issuable, "e:/test2/test2.c");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas/test.c");
+      TestUtils.addInputFile(fs, perspectives, issuable, "e:/randomfoldernamethatihopeknowmachinehas2/test2.c");
       TestUtils.addInputFile(fs, perspectives, issuable, "e:/anotherincludeattop.h");
     }
     else {

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/coverage-reports/bullseye/bullseye-coverage-drive-letter-without-slash-win.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/coverage-reports/bullseye/bullseye-coverage-drive-letter-without-slash-win.xml
@@ -14,7 +14,7 @@
 <probe line="29" kind="decision" event="true"/>
 </fn>
 </src>
-<folder name="test" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
+<folder name="randomfoldernamethatihopeknowmachinehas" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <src name="test.c" mtime="1403633422" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <fn name="test_func(int)" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <probe line="4" column="3" kind="function" event="full"/>
@@ -22,7 +22,7 @@
 </fn>
 </src>
 </folder>
-<folder name="test2" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
+<folder name="randomfoldernamethatihopeknowmachinehas2" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <src name="test2.c" mtime="1404302770" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <fn name="test_func_3(int)" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <probe line="4" column="3" kind="function" event="full"/>

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/coverage-reports/bullseye/bullseye-coverage-report-data-in-root-node-win.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/coverage-reports/bullseye/bullseye-coverage-report-data-in-root-node-win.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BullseyeCoverage name="coverage.cov" dir="e:/test/" buildId="5e0cbdab, 2014-07-02 15:07:32" version="4" xmlns="http://www.bullseye.com/covxml">
+<BullseyeCoverage name="coverage.cov" dir="e:/randomfoldernamethatihopeknowmachinehas/" buildId="5e0cbdab, 2014-07-02 15:07:32" version="4" xmlns="http://www.bullseye.com/covxml">
 <src name="anotherincludeattop.h" mtime="1404302508" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <fn name="test_func_2(int)" fn_cov="1" fn_total="1" cd_cov="1" cd_total="2" d_cov="1" d_total="2">
 <probe line="3" column="3" kind="function" event="full"/>


### PR DESCRIPTION
ok, got it... this getCanonicalPath() is kind of evil. my problem was that i had a folder in e:\ with e:\Test then when this is called with e:\test\askdsa.c it will retrieve E:\Test\askds.c and the tests fail in my environment.  

in real life, we should run the coverage in same machine as the analysis or at least make sure everything is the same across machines. 

@guwirth can you verify this in your environment?