### PR TITLE
Fix NOLINT(*) regression

### DIFF
--- a/sonar-cxx-plugin/src/tools/cpplint_createrules.py
+++ b/sonar-cxx-plugin/src/tools/cpplint_createrules.py
@@ -37,7 +37,7 @@ def WriteUpdateFile(filename):
             filetowrite.write('            category = value\n')
         if linei.startswith('  return (linenum in _error_suppressions.get(category, set()) or'):
             filetowrite.write('  for key in _error_suppressions.keys():\n')
-            filetowrite.write('    if category.startswith(key):\n')
+            filetowrite.write('    if key and category.startswith(key):\n')
             filetowrite.write('      category = key\n')
         filetowrite.write(linei)
                                                         


### PR DESCRIPTION
After recent commit was tested over wider existing code
base, it was reported cpplint_mod.py would crash on
source code that contained "// NOLINT(*)".

This regression was fixed and tested against this fuller
(fullest) set of cases.  First two are "mask all lint reports"
wildcards.

    #include <thread>
    #include <thread>  // NOLINT
    #include <thread>  // NOLINT(*)
    #include <thread>  // NOLINT(build/c++11)
    #include <thread>  // NOLINT(build/c++11-2)